### PR TITLE
Improve hunter spawning distance and speed

### DIFF
--- a/src/ServerScriptService/EnemySpawner.server.lua
+++ b/src/ServerScriptService/EnemySpawner.server.lua
@@ -4,14 +4,34 @@ local Players = game:GetService("Players")
 
 local Config = require(Replicated.Modules.RoundConfig)
 
-local function createEnemy()
-	-- Build a simple R15-like NPC (Humanoid R15, HRP + Head + Torso)
-	local enemy = Instance.new("Model")
-	enemy.Name = "Hunter"
-	local hum = Instance.new("Humanoid"); hum.RigType = Enum.HumanoidRigType.R15; hum.WalkSpeed = 14; hum.Parent = enemy
-	local root = Instance.new("Part")
-	root.Name = "HumanoidRootPart"; root.Size = Vector3.new(2,2,1); root.Anchored = false
-	local head = Instance.new("Part"); head.Name = "Head"; head.Size = Vector3.new(2,1,2); head.Anchored = false; head.Parent = enemy
+local function getMaxPlayerSpeed()
+        local maxSpeed = 0
+        for _, plr in ipairs(Players:GetPlayers()) do
+                local char = plr.Character
+                if char then
+                        local hum = char:FindFirstChildOfClass("Humanoid")
+                        if hum and hum.WalkSpeed > maxSpeed then
+                                maxSpeed = hum.WalkSpeed
+                        end
+                end
+        end
+        if maxSpeed <= 0 then
+                maxSpeed = 16
+        end
+        return maxSpeed
+end
+
+local function createEnemy(speed)
+        -- Build a simple R15-like NPC (Humanoid R15, HRP + Head + Torso)
+        local enemy = Instance.new("Model")
+        enemy.Name = "Hunter"
+        local hum = Instance.new("Humanoid")
+        hum.RigType = Enum.HumanoidRigType.R15
+        hum.WalkSpeed = speed
+        hum.Parent = enemy
+        local root = Instance.new("Part")
+        root.Name = "HumanoidRootPart"; root.Size = Vector3.new(2,2,1); root.Anchored = false
+        local head = Instance.new("Part"); head.Name = "Head"; head.Size = Vector3.new(2,1,2); head.Anchored = false; head.Parent = enemy
 	local weld = Instance.new("WeldConstraint"); weld.Part0 = root; weld.Part1 = head; weld.Parent = enemy
 	root.Parent = enemy
 	enemy.PrimaryPart = root
@@ -19,29 +39,103 @@ local function createEnemy()
 	return enemy
 end
 
-local function closestPlayerPosition()
-	-- returns HRP.Position of the closest valid player, or nil
-	local closestPos; local minDist = math.huge
-	for _, plr in ipairs(Players:GetPlayers()) do
-		local char = plr.Character
-		if char and char:FindFirstChild("HumanoidRootPart") then
-			local pos = char.HumanoidRootPart.Position
-			local dist = (pos - Vector3.new(0,0,0)).Magnitude
-			if dist < minDist then minDist = dist; closestPos = pos end
-		end
-	end
-	return closestPos
+local function closestPlayerPosition(fromPos)
+        -- returns HRP.Position of the closest valid player to fromPos, or nil
+        local closestPos; local minDist = math.huge
+        for _, plr in ipairs(Players:GetPlayers()) do
+                local char = plr.Character
+                if char and char:FindFirstChild("HumanoidRootPart") then
+                        local pos = char.HumanoidRootPart.Position
+                        local dist
+                        if fromPos then
+                                dist = (pos - fromPos).Magnitude
+                        else
+                                dist = pos.Magnitude
+                        end
+                        if dist < minDist then minDist = dist; closestPos = pos end
+                end
+        end
+        return closestPos
+end
+
+local function computePathDistance(fromPos, toPos)
+        local path = PathfindingService:CreatePath()
+        local ok = pcall(function()
+                path:ComputeAsync(fromPos, toPos)
+        end)
+        if not ok or path.Status ~= Enum.PathStatus.Success then
+                return math.huge
+        end
+        local waypoints = path:GetWaypoints()
+        local prev = fromPos
+        local distance = 0
+        for _, waypoint in ipairs(waypoints) do
+                distance += (waypoint.Position - prev).Magnitude
+                prev = waypoint.Position
+        end
+        distance += (toPos - prev).Magnitude
+        return distance
+end
+
+local function randomCellPosition()
+        local x = math.random(1, Config.GridWidth)
+        local z = math.random(1, Config.GridHeight)
+        return Vector3.new((x - 0.5) * Config.CellSize, 3, (z - 0.5) * Config.CellSize)
+end
+
+local function findSpawnPosition(enemySpeed)
+        local players = Players:GetPlayers()
+        if #players == 0 then
+                return randomCellPosition()
+        end
+
+        local requiredDistance = enemySpeed * 5
+        local bestPos
+        local bestDistance = 0
+
+        for _ = 1, 200 do
+                local candidate = randomCellPosition()
+                local minDistance = math.huge
+                local valid = true
+
+                for _, plr in ipairs(players) do
+                        local char = plr.Character
+                        local hrp = char and char:FindFirstChild("HumanoidRootPart")
+                        if hrp then
+                                local distance = computePathDistance(candidate, hrp.Position)
+                                if distance < minDistance then
+                                        minDistance = distance
+                                end
+                                if distance <= requiredDistance then
+                                        valid = false
+                                        break
+                                end
+                        end
+                end
+
+                if valid then
+                        return candidate
+                end
+
+                if minDistance > bestDistance then
+                        bestDistance = minDistance
+                        bestPos = candidate
+                end
+        end
+
+        return bestPos or randomCellPosition()
 end
 
 local function chase(enemy)
-	-- Ensure PrimaryPart
-	if not enemy.PrimaryPart then enemy.PrimaryPart = enemy:FindFirstChild("HumanoidRootPart") end
-	local hum = enemy:FindFirstChildOfClass("Humanoid")
-	while enemy.Parent do
-		local targetPos = closestPlayerPosition()
-		if not targetPos or not enemy.PrimaryPart then task.wait(0.25) continue end
-		local path = PathfindingService:CreatePath()
-		local ok = pcall(function()
+        -- Ensure PrimaryPart
+        if not enemy.PrimaryPart then enemy.PrimaryPart = enemy:FindFirstChild("HumanoidRootPart") end
+        local hum = enemy:FindFirstChildOfClass("Humanoid")
+        while enemy.Parent do
+                local origin = enemy.PrimaryPart and enemy.PrimaryPart.Position or nil
+                local targetPos = closestPlayerPosition(origin)
+                if not targetPos or not enemy.PrimaryPart then task.wait(0.25) continue end
+                local path = PathfindingService:CreatePath()
+                local ok = pcall(function()
 			path:ComputeAsync(enemy.PrimaryPart.Position, targetPos)
 		end)
 		if ok and path.Status == Enum.PathStatus.Success then
@@ -60,10 +154,12 @@ local function chase(enemy)
 end
 
 _G.SpawnHunters = function()
-	for i = 1, Config.EnemyCount do
-		local e = createEnemy()
-		-- Spawn near maze start with small offsets
-		e:SetPrimaryPartCFrame(CFrame.new( (Config.CellSize/2) + (i*2), 4, (Config.CellSize/2) + (i*2) ))
-		task.spawn(chase, e)
-	end
+        local maxPlayerSpeed = getMaxPlayerSpeed()
+        local enemySpeed = maxPlayerSpeed * 0.5
+        for i = 1, Config.EnemyCount do
+                local e = createEnemy(enemySpeed)
+                local spawnPos = findSpawnPosition(enemySpeed)
+                e:SetPrimaryPartCFrame(CFrame.new(spawnPos))
+                task.spawn(chase, e)
+        end
 end


### PR DESCRIPTION
## Summary
- spawn hunters at random maze positions where path distance keeps them at least 5 seconds away from players
- set hunter walk speed to half of the fastest player and target the nearest player relative to each hunter

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e14b6255d08322a85a46fbb6008f1a