### PR TITLE
Ensure key door waits for inventory service

### DIFF
--- a/src/ServerScriptService/InventoryProvider.lua
+++ b/src/ServerScriptService/InventoryProvider.lua
@@ -1,18 +1,29 @@
 local WARN_DELAY = 3
 
+local cachedService
+
 local function waitForInventory()
+        if cachedService then
+                return cachedService
+        end
+
         local start = os.clock()
         local warned = false
 
-        while not _G.Inventory do
+        while true do
+                local inventoryService = _G.Inventory or shared.Inventory
+                if inventoryService then
+                        cachedService = inventoryService
+                        return cachedService
+                end
+
                 if not warned and os.clock() - start >= WARN_DELAY then
                         warn("Inventory service (_G.Inventory) is not available yet. Waiting for it to load...")
                         warned = true
                 end
+
                 task.wait()
         end
-
-        return _G.Inventory
 end
 
 return {

--- a/src/ServerScriptService/InventoryProvider.lua
+++ b/src/ServerScriptService/InventoryProvider.lua
@@ -1,0 +1,20 @@
+local WARN_DELAY = 3
+
+local function waitForInventory()
+        local start = os.clock()
+        local warned = false
+
+        while not _G.Inventory do
+                if not warned and os.clock() - start >= WARN_DELAY then
+                        warn("Inventory service (_G.Inventory) is not available yet. Waiting for it to load...")
+                        warned = true
+                end
+                task.wait()
+        end
+
+        return _G.Inventory
+end
+
+return {
+        getInventory = waitForInventory,
+}

--- a/src/ServerScriptService/InventoryProvider.lua
+++ b/src/ServerScriptService/InventoryProvider.lua
@@ -1,9 +1,22 @@
 local WARN_DELAY = 3
+local RETRY_DELAY = 0.1
 
 local cachedService
 
+local function validateInventory(service)
+        if type(service) ~= "table" then
+                return false
+        end
+
+        if type(service.AddKey) ~= "function" or type(service.UseKey) ~= "function" or type(service.HasKey) ~= "function" then
+                return false
+        end
+
+        return true
+end
+
 local function waitForInventory()
-        if cachedService then
+        if cachedService and validateInventory(cachedService) then
                 return cachedService
         end
 
@@ -12,7 +25,7 @@ local function waitForInventory()
 
         while true do
                 local inventoryService = _G.Inventory or shared.Inventory
-                if inventoryService then
+                if inventoryService and validateInventory(inventoryService) then
                         cachedService = inventoryService
                         return cachedService
                 end
@@ -22,7 +35,7 @@ local function waitForInventory()
                         warned = true
                 end
 
-                task.wait()
+                task.wait(RETRY_DELAY)
         end
 end
 

--- a/src/ServerScriptService/InventoryService.server.lua
+++ b/src/ServerScriptService/InventoryService.server.lua
@@ -21,26 +21,26 @@ end
 local Service = {}
 
 function Service.AddKey(plr, amount)
-	amount = amount or 1
-	local inv = ensure(plr)
-	inv.keys += amount
-	pushClient(plr)
+        amount = amount or 1
+        local inv = ensure(plr)
+        inv.keys = (inv.keys or 0) + amount
+        pushClient(plr)
 end
 
 function Service.HasKey(plr)
-	local inv = ensure(plr)
-	return (inv.keys or 0) > 0
+        local inv = ensure(plr)
+        return (inv.keys or 0) > 0
 end
 
 function Service.UseKey(plr, amount)
-	amount = amount or 1
-	local inv = ensure(plr)
-	if (inv.keys or 0) >= amount then
-		inv.keys -= amount
-		pushClient(plr)
-		return true
-	end
-	return false
+        amount = amount or 1
+        local inv = ensure(plr)
+        if (inv.keys or 0) >= amount then
+                inv.keys = (inv.keys or 0) - amount
+                pushClient(plr)
+                return true
+        end
+        return false
 end
 
 _G.Inventory = Service

--- a/src/ServerScriptService/InventoryService.server.lua
+++ b/src/ServerScriptService/InventoryService.server.lua
@@ -44,6 +44,7 @@ function Service.UseKey(plr, amount)
 end
 
 _G.Inventory = Service
+shared.Inventory = Service
 
 Players.PlayerAdded:Connect(function(plr)
 	ensure(plr)

--- a/src/ServerScriptService/KeyDoorService.server.lua
+++ b/src/ServerScriptService/KeyDoorService.server.lua
@@ -10,45 +10,77 @@ local prefabs = ServerStorage:WaitForChild("Prefabs")
 local InventoryProvider = require(ServerScriptService:WaitForChild("InventoryProvider"))
 
 local function placeModelRandom(model, gridWidth, gridHeight, cellSize)
-	local m = model:Clone()
-	local rx = math.random(1, gridWidth)
-	local ry = math.random(1, gridHeight)
-	m:PivotTo(CFrame.new(rx*cellSize - (cellSize/2), 2, ry*cellSize - (cellSize/2)))
-	m.Parent = workspace.Maze
-	return m
+    local m = model:Clone()
+    local rx = math.random(1, gridWidth)
+    local ry = math.random(1, gridHeight)
+    m:PivotTo(CFrame.new(rx * cellSize - (cellSize / 2), 2, ry * cellSize - (cellSize / 2)))
+    m.Parent = workspace.Maze
+    return m
 end
 
 _G.KeyDoor_OnRoundStart = function()
-	for i = 1, Config.KeyCount do
-		local key = prefabs.Key:Clone(); key.Name = "Key_"..i
-		placeModelRandom(key, Config.GridWidth, Config.GridHeight, Config.CellSize)
-		local pp = key:FindFirstChildWhichIsA("ProximityPrompt", true)
-		if not pp then pp = Instance.new("ProximityPrompt"); pp.Parent = key:FindFirstChildWhichIsA("BasePart") end
-		pp.ActionText = "Pickup Key"
-                pp.Triggered:Connect(function(plr)
-                        local inventory = InventoryProvider.getInventory()
-                        if inventory then
-                                inventory.AddKey(plr, 1)
-                        end
-                        Pickup:FireClient(plr, "Key")
-                        key:Destroy()
-                end)
-	end
-	local door = prefabs.Door:Clone(); door.Name = "ExitDoor"
-	local rx = Config.GridWidth; local ry = Config.GridHeight - 1
-	door:PivotTo(CFrame.new(rx*Config.CellSize - (Config.CellSize/2), 4, ry*Config.CellSize - (Config.CellSize/2)))
-	door.Parent = workspace.Maze
-	local locked = door:FindFirstChild("Locked"); if not locked then locked = Instance.new("BoolValue", door); locked.Name = "Locked"; locked.Value = true end
-	-- Proximity prompt to unlock door (server-side check)
-	local panel = door:FindFirstChild("Panel") or door.PrimaryPart
-	local prompt = panel:FindFirstChildOfClass("ProximityPrompt") or Instance.new("ProximityPrompt"); prompt.Parent = panel; prompt.ActionText = "Unlock Door"; prompt.ObjectText = "Exit Door"; prompt.RequiresLineOfSight = false
-        prompt.Triggered:Connect(function(plr)
-                if not locked.Value then return end
-                local inventory = InventoryProvider.getInventory()
-                if inventory and inventory.HasKey(plr) and inventory.UseKey(plr,1) then
-                        locked.Value = false
-                        for _, part in ipairs(door:GetDescendants()) do if part:IsA("BasePart") then part.CanCollide = false end end
-                        door:Destroy()
-                end
+    for i = 1, Config.KeyCount do
+        local key = prefabs.Key:Clone()
+        key.Name = "Key_" .. i
+        placeModelRandom(key, Config.GridWidth, Config.GridHeight, Config.CellSize)
+        local pp = key:FindFirstChildWhichIsA("ProximityPrompt", true)
+        if not pp then
+            pp = Instance.new("ProximityPrompt")
+            pp.Parent = key:FindFirstChildWhichIsA("BasePart")
+        end
+        pp.ActionText = "Pickup Key"
+        pp.Triggered:Connect(function(plr)
+            local inventory = InventoryProvider.getInventory()
+            if not inventory then
+                warn("KeyDoorService: Inventory service unavailable when picking up a key")
+                return
+            end
+
+            inventory.AddKey(plr, 1)
+            if Pickup then
+                Pickup:FireClient(plr, "Key")
+            end
+            key:Destroy()
         end)
+    end
+    local door = prefabs.Door:Clone()
+    door.Name = "ExitDoor"
+    local rx = Config.GridWidth
+    local ry = Config.GridHeight - 1
+    door:PivotTo(CFrame.new(rx * Config.CellSize - (Config.CellSize / 2), 4, ry * Config.CellSize - (Config.CellSize / 2)))
+    door.Parent = workspace.Maze
+    local locked = door:FindFirstChild("Locked")
+    if not locked then
+        locked = Instance.new("BoolValue", door)
+        locked.Name = "Locked"
+        locked.Value = true
+    end
+    -- Proximity prompt to unlock door (server-side check)
+    local panel = door:FindFirstChild("Panel") or door.PrimaryPart
+    local prompt = panel:FindFirstChildOfClass("ProximityPrompt") or Instance.new("ProximityPrompt")
+    prompt.Parent = panel
+    prompt.ActionText = "Unlock Door"
+    prompt.ObjectText = "Exit Door"
+    prompt.RequiresLineOfSight = false
+    prompt.Triggered:Connect(function(plr)
+        if not locked.Value then
+            return
+        end
+
+        local inventory = InventoryProvider.getInventory()
+        if not inventory then
+            warn("KeyDoorService: Inventory service unavailable when unlocking the door")
+            return
+        end
+
+        if inventory.HasKey(plr) and inventory.UseKey(plr, 1) then
+            locked.Value = false
+            for _, part in ipairs(door:GetDescendants()) do
+                if part:IsA("BasePart") then
+                    part.CanCollide = false
+                end
+            end
+            door:Destroy()
+        end
+    end)
 end

--- a/src/ServerScriptService/KeyDoorService.server.lua
+++ b/src/ServerScriptService/KeyDoorService.server.lua
@@ -9,17 +9,38 @@ local Pickup = Remotes:FindFirstChild("Pickup")
 local prefabs = ServerStorage:WaitForChild("Prefabs")
 local InventoryProvider = require(ServerScriptService:WaitForChild("InventoryProvider"))
 
-local function ensureBarrierPart(parent, name, size, cframe)
+local DEFAULT_BARRIER_COLOR = Color3.fromRGB(60, 60, 60)
+
+local function applyAppearanceFromSource(part, source)
+    if source and source:IsA("BasePart") then
+        part.Material = source.Material
+        part.Color = source.Color
+        part.Transparency = source.Transparency
+        part.Reflectance = source.Reflectance
+        part.CastShadow = source.CastShadow
+    else
+        part.Material = Enum.Material.Metal
+        part.Color = DEFAULT_BARRIER_COLOR
+        part.Transparency = 0
+        part.Reflectance = 0
+        part.CastShadow = true
+    end
+end
+
+local function ensureBarrierPart(parent, name, size, cframe, appearanceSource)
     local part = parent:FindFirstChild(name)
     if not (part and part:IsA("BasePart")) then
         part = Instance.new("Part")
         part.Name = name
         part.Anchored = true
-        part.Material = Enum.Material.ForceField
-        part.Transparency = 1
         part.CanQuery = false
         part.CanTouch = false
         part.Parent = parent
+    end
+
+    applyAppearanceFromSource(part, appearanceSource)
+    if part.Transparency >= 1 then
+        part.Transparency = 0
     end
 
     part.Size = size
@@ -105,7 +126,13 @@ local function ensureExitBarrier(door, fallbackPanel)
     local depthOffset = math.max(Config.CellSize / 2, depth / 2)
     local basePosition = referencePanel.Position
 
-    local frontBarrier = ensureBarrierPart(door, "ExitBarrier", Vector3.new(width, height, depth), referencePanel.CFrame)
+    local frontBarrier = ensureBarrierPart(
+        door,
+        "ExitBarrier",
+        Vector3.new(width, height, depth),
+        referencePanel.CFrame,
+        referencePanel
+    )
 
     ensureBarrierPart(
         door,
@@ -116,7 +143,8 @@ local function ensureExitBarrier(door, fallbackPanel)
             orientedRight,
             up,
             orientedLook
-        )
+        ),
+        referencePanel
     )
 
     ensureBarrierPart(
@@ -128,7 +156,8 @@ local function ensureExitBarrier(door, fallbackPanel)
             orientedRight,
             up,
             orientedLook
-        )
+        ),
+        referencePanel
     )
 
     ensureBarrierPart(
@@ -140,7 +169,8 @@ local function ensureExitBarrier(door, fallbackPanel)
             orientedRight,
             up,
             orientedLook
-        )
+        ),
+        referencePanel
     )
 
     return frontBarrier
@@ -157,7 +187,7 @@ local function ensureExitPadBarrier()
     local size = Vector3.new(Config.CellSize, 20, Config.CellSize)
     local cframe = CFrame.new(exitPad.Position.X, size.Y / 2, exitPad.Position.Z)
 
-    return ensureBarrierPart(spawns, "ExitPadBarrier", size, cframe)
+    return ensureBarrierPart(spawns, "ExitPadBarrier", size, cframe, exitPad)
 end
 
 local function getInventoryOrWarn(context)

--- a/src/ServerScriptService/KeyDoorService.server.lua
+++ b/src/ServerScriptService/KeyDoorService.server.lua
@@ -18,30 +18,147 @@ local function placeModelRandom(model, gridWidth, gridHeight, cellSize)
     return m
 end
 
+local function getInventoryOrWarn(context)
+    local ok, inventory = pcall(InventoryProvider.getInventory)
+    if not ok then
+        warn("KeyDoorService: Failed to resolve inventory service (" .. tostring(context) .. "): " .. tostring(inventory))
+        return nil
+    end
+
+    if not inventory then
+        warn("KeyDoorService: Inventory service unavailable (" .. tostring(context) .. ")")
+        return nil
+    end
+
+    return inventory
+end
+
+local function safelyCall(inventory, methodName, ...)
+    if type(inventory[methodName]) ~= "function" then
+        warn("KeyDoorService: Inventory service missing method " .. methodName)
+        return false
+    end
+
+    local ok, result = pcall(inventory[methodName], ...)
+    if not ok then
+        warn("KeyDoorService: Inventory service threw during " .. methodName .. ": " .. tostring(result))
+        return false
+    end
+
+    return result ~= nil and result or true
+end
+
+local function configureKeyPrompt(keyModel)
+    local prompt = keyModel:FindFirstChildWhichIsA("ProximityPrompt", true)
+    if not prompt then
+        local targetPart = keyModel:FindFirstChildWhichIsA("BasePart")
+        if not targetPart then
+            warn("KeyDoorService: Key prefab has no BasePart to attach prompt")
+            return
+        end
+
+        prompt = Instance.new("ProximityPrompt")
+        prompt.Parent = targetPart
+    end
+
+    prompt.ActionText = "Pick Up Key"
+    prompt.ObjectText = "Key"
+    prompt.HoldDuration = 0
+    prompt.RequiresLineOfSight = false
+    prompt.MaxActivationDistance = 12
+
+    prompt.Triggered:Connect(function(plr)
+        if not plr or not plr:IsA("Player") then
+            return
+        end
+
+        prompt.Enabled = false
+
+        local inventory = getInventoryOrWarn("picking up a key")
+        if not inventory then
+            prompt.Enabled = true
+            return
+        end
+
+        local added = safelyCall(inventory, "AddKey", plr, 1)
+        if not added then
+            prompt.Enabled = true
+            return
+        end
+
+        if Pickup then
+            Pickup:FireClient(plr, "Key")
+        end
+
+        keyModel:Destroy()
+    end)
+end
+
+local function configureDoorPrompt(door, lockedValue)
+    local panel = door:FindFirstChild("Panel") or door.PrimaryPart
+    if not panel then
+        warn("KeyDoorService: Door prefab missing a primary part or panel")
+        return
+    end
+
+    local prompt = panel:FindFirstChildOfClass("ProximityPrompt") or Instance.new("ProximityPrompt")
+    prompt.Parent = panel
+    prompt.ActionText = "Unlock Door"
+    prompt.ObjectText = "Exit Door"
+    prompt.RequiresLineOfSight = false
+    prompt.MaxActivationDistance = 10
+
+    prompt.Triggered:Connect(function(plr)
+        if not plr or not plr:IsA("Player") then
+            return
+        end
+
+        if not lockedValue.Value then
+            return
+        end
+
+        prompt.Enabled = false
+
+        local inventory = getInventoryOrWarn("unlocking the exit door")
+        if not inventory then
+            prompt.Enabled = true
+            return
+        end
+
+        local hasKey = safelyCall(inventory, "HasKey", plr)
+        if not hasKey then
+            prompt.Enabled = true
+            return
+        end
+
+        local consumed = safelyCall(inventory, "UseKey", plr, 1)
+        if not consumed then
+            prompt.Enabled = true
+            return
+        end
+
+        lockedValue.Value = false
+
+        for _, part in ipairs(door:GetDescendants()) do
+            if part:IsA("BasePart") then
+                part.CanCollide = false
+            end
+        end
+
+        if DoorOpened then
+            DoorOpened:FireAllClients()
+        end
+
+        door:Destroy()
+    end)
+end
+
 _G.KeyDoor_OnRoundStart = function()
     for i = 1, Config.KeyCount do
         local key = prefabs.Key:Clone()
         key.Name = "Key_" .. i
         placeModelRandom(key, Config.GridWidth, Config.GridHeight, Config.CellSize)
-        local pp = key:FindFirstChildWhichIsA("ProximityPrompt", true)
-        if not pp then
-            pp = Instance.new("ProximityPrompt")
-            pp.Parent = key:FindFirstChildWhichIsA("BasePart")
-        end
-        pp.ActionText = "Pickup Key"
-        pp.Triggered:Connect(function(plr)
-            local inventory = InventoryProvider.getInventory()
-            if not inventory then
-                warn("KeyDoorService: Inventory service unavailable when picking up a key")
-                return
-            end
-
-            inventory.AddKey(plr, 1)
-            if Pickup then
-                Pickup:FireClient(plr, "Key")
-            end
-            key:Destroy()
-        end)
+        configureKeyPrompt(key)
     end
     local door = prefabs.Door:Clone()
     door.Name = "ExitDoor"
@@ -56,31 +173,5 @@ _G.KeyDoor_OnRoundStart = function()
         locked.Value = true
     end
     -- Proximity prompt to unlock door (server-side check)
-    local panel = door:FindFirstChild("Panel") or door.PrimaryPart
-    local prompt = panel:FindFirstChildOfClass("ProximityPrompt") or Instance.new("ProximityPrompt")
-    prompt.Parent = panel
-    prompt.ActionText = "Unlock Door"
-    prompt.ObjectText = "Exit Door"
-    prompt.RequiresLineOfSight = false
-    prompt.Triggered:Connect(function(plr)
-        if not locked.Value then
-            return
-        end
-
-        local inventory = InventoryProvider.getInventory()
-        if not inventory then
-            warn("KeyDoorService: Inventory service unavailable when unlocking the door")
-            return
-        end
-
-        if inventory.HasKey(plr) and inventory.UseKey(plr, 1) then
-            locked.Value = false
-            for _, part in ipairs(door:GetDescendants()) do
-                if part:IsA("BasePart") then
-                    part.CanCollide = false
-                end
-            end
-            door:Destroy()
-        end
-    end)
+    configureDoorPrompt(door, locked)
 end


### PR DESCRIPTION
## Summary
- add a shared InventoryProvider module that waits for the global inventory service and warns while it loads
- update KeyDoorService to fetch the inventory on demand for key pickups and door unlocking

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1808767dc8322b004b69feb129d4b