### PR TITLE
Fix inventory state initialization order

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
@@ -35,16 +35,6 @@ btnPRIM.MouseButton1Click:Connect(function()
 	SetMazeAlgorithm:FireServer("PRIM")
 end)
 
-RoundState.OnClientEvent:Connect(function(state) status.Text = "State: " .. tostring(state) end)
-Countdown.OnClientEvent:Connect(function(t) timerLbl.Text = "Time: " .. t end)
-Pickup.OnClientEvent:Connect(function(item)
-        if item == "Key" then
-                inventoryState.keys += 1
-                updateInventoryLabel()
-        end
-end)
-local InventoryUpdate = Replicated.Remotes:WaitForChild("InventoryUpdate")
-
 local btnExit, btnHunter
 local exitDistanceLbl, hunterDistanceLbl
 local updateFinderButtonStates
@@ -69,6 +59,16 @@ local function updateInventoryLabel()
                 hunterStatus
         )
 end
+
+RoundState.OnClientEvent:Connect(function(state) status.Text = "State: " .. tostring(state) end)
+Countdown.OnClientEvent:Connect(function(t) timerLbl.Text = "Time: " .. t end)
+Pickup.OnClientEvent:Connect(function(item)
+        if item == "Key" then
+                inventoryState.keys += 1
+                updateInventoryLabel()
+        end
+end)
+local InventoryUpdate = Replicated.Remotes:WaitForChild("InventoryUpdate")
 
 InventoryUpdate.OnClientEvent:Connect(function(data)
         inventoryState.keys = (data and data.keys) or inventoryState.keys


### PR DESCRIPTION
## Summary
- ensure the client inventory state is initialized before pickup events fire
- update key pickup handler to safely increment the local key count

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e19af976fc8322bf5239c316f7f485