### PR TITLE
Prevent client UI from double counting key pickups

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
@@ -64,8 +64,10 @@ RoundState.OnClientEvent:Connect(function(state) status.Text = "State: " .. tost
 Countdown.OnClientEvent:Connect(function(t) timerLbl.Text = "Time: " .. t end)
 Pickup.OnClientEvent:Connect(function(item)
         if item == "Key" then
-                inventoryState.keys += 1
-                updateInventoryLabel()
+                -- The server immediately sends an authoritative inventory update
+                -- after awarding a key. Avoid updating the local count here so
+                -- we don't double-count when that update arrives.
+                return
         end
 end)
 local InventoryUpdate = Replicated.Remotes:WaitForChild("InventoryUpdate")


### PR DESCRIPTION
## Summary
- stop the client from incrementing the key counter when the server already broadcasts the updated total
- rely on the inventory update event to avoid awarding two keys on the first pickup and when unlocking the exit

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1a20ab8cc8322ad0413799e66799d