### PR TITLE
Make player spawn location invisible

### DIFF
--- a/src/ServerScriptService/GameManager.server.lua
+++ b/src/ServerScriptService/GameManager.server.lua
@@ -21,7 +21,7 @@ algoValue.Name = "MazeAlgorithm"; algoValue.Value = "DFS"
 
 local mazeFolder = Workspace:FindFirstChild("Maze") or Instance.new("Folder", Workspace); mazeFolder.Name = "Maze"
 local spawns = Workspace:FindFirstChild("Spawns") or Instance.new("Folder", Workspace); spawns.Name = "Spawns"
-local playerSpawn = spawns:FindFirstChild("PlayerSpawn") or Instance.new("SpawnLocation", spawns); playerSpawn.Name = "PlayerSpawn"; playerSpawn.Anchored = true; playerSpawn.Enabled = true; playerSpawn.Size = Vector3.new(10,1,10)
+local playerSpawn = spawns:FindFirstChild("PlayerSpawn") or Instance.new("SpawnLocation", spawns); playerSpawn.Name = "PlayerSpawn"; playerSpawn.Anchored = true; playerSpawn.Enabled = true; playerSpawn.Size = Vector3.new(10,1,10); playerSpawn.Transparency = 1; playerSpawn.CanCollide = false; playerSpawn.CanTouch = false
 
 -- Lobby base
 local lobbyBase = spawns:FindFirstChild("LobbyBase") or Instance.new("Part", spawns); lobbyBase.Name = "LobbyBase"; lobbyBase.Anchored = true; lobbyBase.Size = Vector3.new(80,1,80); lobbyBase.Material = Enum.Material.Glass; lobbyBase.Transparency = 0.4


### PR DESCRIPTION
## Summary
- hide the PlayerSpawn location by setting transparency and disabling collision/touch

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1a83abd008322973b42f565865aae