### PR TITLE
Lock camera to first-person perspective

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/FirstPersonCamera.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/FirstPersonCamera.client.lua
@@ -1,11 +1,15 @@
 local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Workspace = game:GetService("Workspace")
 
 local player = Players.LocalPlayer
 local remotes = ReplicatedStorage:WaitForChild("Remotes")
 local roundStateEvent = remotes:WaitForChild("RoundState")
 local stateFolder = ReplicatedStorage:FindFirstChild("State")
+
+local spawnsFolder = Workspace:FindFirstChild("Spawns")
+local lobbyBase = spawnsFolder and spawnsFolder:FindFirstChild("LobbyBase")
 
 local MIN_ZOOM = 0.5
 local MAX_ZOOM = 0.5
@@ -15,6 +19,46 @@ local originalMinZoom = player.CameraMinZoomDistance
 local originalMaxZoom = player.CameraMaxZoomDistance
 
 local firstPersonActive = false
+local currentPhase = "IDLE"
+
+local function getHumanoidRootPart(character)
+    local char = character or player.Character
+    if not char then
+        return nil
+    end
+    return char:FindFirstChild("HumanoidRootPart")
+end
+
+local function isInLobby()
+    local root = getHumanoidRootPart()
+    if not root then
+        return false
+    end
+
+    if lobbyBase then
+        -- Treat anything near or above the lobby platform height as being in the lobby.
+        local lobbyHeight = lobbyBase.Position.Y
+        local margin = (lobbyBase.Size.Y / 2) + 2
+        if root.Position.Y >= lobbyHeight - margin then
+            return true
+        end
+    end
+
+    return false
+end
+
+local function shouldLockFirstPerson()
+    if currentPhase ~= "ACTIVE" then
+        return false
+    end
+
+    -- Only force first-person while the player is actually inside the maze.
+    if isInLobby() then
+        return false
+    end
+
+    return true
+end
 
 local function setCameraSubject(character)
     task.spawn(function()
@@ -52,7 +96,7 @@ local function disableFirstPerson()
 end
 
 local function onCharacterAdded(character)
-    if firstPersonActive then
+    if shouldLockFirstPerson() then
         enableFirstPerson()
     else
         -- Ensure lobby defaults are respected when respawning outside the maze.
@@ -61,7 +105,9 @@ local function onCharacterAdded(character)
 end
 
 local function updateForPhase(phase)
-    if phase == "ACTIVE" then
+    currentPhase = phase
+
+    if shouldLockFirstPerson() then
         enableFirstPerson()
     else
         disableFirstPerson()
@@ -74,6 +120,14 @@ end
 player.CharacterAdded:Connect(onCharacterAdded)
 
 RunService:BindToRenderStep("EnforceMazeFirstPerson", Enum.RenderPriority.Camera.Value + 1, function()
+    local shouldLock = shouldLockFirstPerson()
+
+    if shouldLock and not firstPersonActive then
+        enableFirstPerson()
+    elseif not shouldLock and firstPersonActive then
+        disableFirstPerson()
+    end
+
     if not firstPersonActive then
         return
     end

--- a/src/StarterPlayer/StarterPlayerScripts/FirstPersonCamera.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/FirstPersonCamera.client.lua
@@ -148,11 +148,43 @@ local function enableFirstPerson()
     setCameraSubject(player.Character)
 end
 
+local function snapCameraBehindCharacter()
+    local camera = workspace.CurrentCamera
+    if not camera then
+        return
+    end
+
+    local humanoid = getHumanoid()
+    local root = getHumanoidRootPart()
+    if not humanoid or not root then
+        return
+    end
+
+    local desiredDistance = (originalMinZoom + originalMaxZoom) * 0.5
+    if desiredDistance < originalMinZoom then
+        desiredDistance = originalMinZoom
+    elseif desiredDistance > originalMaxZoom then
+        desiredDistance = originalMaxZoom
+    end
+
+    local heightOffset = math.clamp(desiredDistance * 0.4, 2, 8)
+
+    local lookAtPosition = root.Position + Vector3.new(0, humanoid.HipHeight or 0, 0)
+    local cameraPosition = lookAtPosition - root.CFrame.LookVector * desiredDistance + Vector3.new(0, heightOffset, 0)
+
+    camera.CameraType = Enum.CameraType.Custom
+    camera.CameraSubject = humanoid
+    camera.CFrame = CFrame.new(cameraPosition, lookAtPosition)
+end
+
 local function disableFirstPerson()
     if not firstPersonActive then
         player.CameraMode = originalMode
         player.CameraMinZoomDistance = originalMinZoom
         player.CameraMaxZoomDistance = originalMaxZoom
+        if not shouldLockFirstPerson() then
+            snapCameraBehindCharacter()
+        end
         return
     end
 
@@ -160,6 +192,9 @@ local function disableFirstPerson()
     player.CameraMode = originalMode
     player.CameraMinZoomDistance = originalMinZoom
     player.CameraMaxZoomDistance = originalMaxZoom
+    if not shouldLockFirstPerson() then
+        snapCameraBehindCharacter()
+    end
 end
 
 local function disconnectCharacterConnections()

--- a/src/StarterPlayer/StarterPlayerScripts/FirstPersonCamera.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/FirstPersonCamera.client.lua
@@ -1,0 +1,42 @@
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
+
+local player = Players.LocalPlayer
+
+local MIN_ZOOM = 0.5
+local MAX_ZOOM = 0.5
+
+local function applyCameraSettings(character)
+    local humanoid = character:FindFirstChildOfClass("Humanoid") or character:WaitForChild("Humanoid")
+    local camera = workspace.CurrentCamera
+
+    player.CameraMode = Enum.CameraMode.LockFirstPerson
+    player.CameraMinZoomDistance = MIN_ZOOM
+    player.CameraMaxZoomDistance = MAX_ZOOM
+
+    if camera then
+        camera.CameraSubject = humanoid
+    end
+end
+
+local function onCharacterAdded(character)
+    applyCameraSettings(character)
+end
+
+if player.Character then
+    applyCameraSettings(player.Character)
+end
+
+player.CharacterAdded:Connect(onCharacterAdded)
+
+RunService:BindToRenderStep("EnforceFirstPersonCamera", Enum.RenderPriority.Camera.Value + 1, function()
+    if player.CameraMode ~= Enum.CameraMode.LockFirstPerson then
+        player.CameraMode = Enum.CameraMode.LockFirstPerson
+    end
+    if player.CameraMinZoomDistance ~= MIN_ZOOM then
+        player.CameraMinZoomDistance = MIN_ZOOM
+    end
+    if player.CameraMaxZoomDistance ~= MAX_ZOOM then
+        player.CameraMaxZoomDistance = MAX_ZOOM
+    end
+end)

--- a/src/StarterPlayer/StarterPlayerScripts/FirstPersonCamera.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/FirstPersonCamera.client.lua
@@ -1,35 +1,83 @@
 local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local player = Players.LocalPlayer
+local remotes = ReplicatedStorage:WaitForChild("Remotes")
+local roundStateEvent = remotes:WaitForChild("RoundState")
+local stateFolder = ReplicatedStorage:FindFirstChild("State")
 
 local MIN_ZOOM = 0.5
 local MAX_ZOOM = 0.5
 
-local function applyCameraSettings(character)
-    local humanoid = character:FindFirstChildOfClass("Humanoid") or character:WaitForChild("Humanoid")
-    local camera = workspace.CurrentCamera
+local originalMode = player.CameraMode
+local originalMinZoom = player.CameraMinZoomDistance
+local originalMaxZoom = player.CameraMaxZoomDistance
 
+local firstPersonActive = false
+
+local function setCameraSubject(character)
+    task.spawn(function()
+        local char = character or player.Character or player.CharacterAdded:Wait()
+        local humanoid = char:FindFirstChildOfClass("Humanoid") or char:WaitForChild("Humanoid")
+        local camera = workspace.CurrentCamera
+        if camera and humanoid then
+            camera.CameraSubject = humanoid
+        end
+    end)
+end
+
+local function enableFirstPerson()
+    if firstPersonActive then
+        setCameraSubject(player.Character)
+        return
+    end
+
+    firstPersonActive = true
     player.CameraMode = Enum.CameraMode.LockFirstPerson
     player.CameraMinZoomDistance = MIN_ZOOM
     player.CameraMaxZoomDistance = MAX_ZOOM
+    setCameraSubject(player.Character)
+end
 
-    if camera then
-        camera.CameraSubject = humanoid
+local function disableFirstPerson()
+    if not firstPersonActive then
+        return
     end
+
+    firstPersonActive = false
+    player.CameraMode = originalMode
+    player.CameraMinZoomDistance = originalMinZoom
+    player.CameraMaxZoomDistance = originalMaxZoom
 end
 
 local function onCharacterAdded(character)
-    applyCameraSettings(character)
+    if firstPersonActive then
+        enableFirstPerson()
+    else
+        -- Ensure lobby defaults are respected when respawning outside the maze.
+        disableFirstPerson()
+    end
+end
+
+local function updateForPhase(phase)
+    if phase == "ACTIVE" then
+        enableFirstPerson()
+    else
+        disableFirstPerson()
+    end
 end
 
 if player.Character then
-    applyCameraSettings(player.Character)
+    onCharacterAdded(player.Character)
 end
-
 player.CharacterAdded:Connect(onCharacterAdded)
 
-RunService:BindToRenderStep("EnforceFirstPersonCamera", Enum.RenderPriority.Camera.Value + 1, function()
+RunService:BindToRenderStep("EnforceMazeFirstPerson", Enum.RenderPriority.Camera.Value + 1, function()
+    if not firstPersonActive then
+        return
+    end
+
     if player.CameraMode ~= Enum.CameraMode.LockFirstPerson then
         player.CameraMode = Enum.CameraMode.LockFirstPerson
     end
@@ -40,3 +88,13 @@ RunService:BindToRenderStep("EnforceFirstPersonCamera", Enum.RenderPriority.Came
         player.CameraMaxZoomDistance = MAX_ZOOM
     end
 end)
+
+roundStateEvent.OnClientEvent:Connect(updateForPhase)
+
+if stateFolder then
+    local phaseValue = stateFolder:FindFirstChild("Phase")
+    if phaseValue then
+        updateForPhase(phaseValue.Value)
+        phaseValue:GetPropertyChangedSignal("Value"):Connect(updateForPhase)
+    end
+end


### PR DESCRIPTION
## Summary
- force the local player camera into first-person mode on spawn
- lock zoom distance to prevent pulling the camera out of the avatar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1a8180b5883229350abc3b0c8abb0