### PR TITLE
Add configurable loop chance to maze generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 ## Wat is nieuw
 - **Server-authoritatieve toggle** tussen `DFS` en `PRIM` via `ReplicatedStorage/State/MazeAlgorithm`.
-- **Lobby UI** met knoppen (DFS/PRIM). Client vraagt wissel aan; server valideert en zet de StringValue.
-- **MazeGenerator** leest runtime-waarde; valt terug op `RoundConfig.MazeAlgorithm` bij ontbreken.
+- **LoopChance**: stel in welk percentage muren na generatie verwijderd wordt (maakt lussen).
+- **Lobby UI** met knoppen (DFS/PRIM + loop-kans). Client vraagt wissels aan; server valideert en zet de waardes.
+- **MazeGenerator** leest runtime-waardes; valt terug op `RoundConfig` bij ontbreken.
 
 ## Snel starten
 1. `rojo serve` of `rojo build --output MazeRush.rbxlx`
@@ -11,8 +12,8 @@
 3. Druk **Play**. Tijdens PREP of in de lobby kun je rechtsboven **DFS/PRIM** kiezen.
 
 ## Bestanden
-- `src/ReplicatedStorage/Modules/MazeGenerator.lua` – bevat DFS én Prim en leest `State.MazeAlgorithm`.
+- `src/ReplicatedStorage/Modules/MazeGenerator.lua` – bevat DFS/Prim en verwerkt `State.MazeAlgorithm` en `LoopChance`.
 - `src/ServerScriptService/AlgorithmService.server.lua` – valideert client-verzoeken en zet server-state.
-- `src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua` – UI voor toggle en basis HUD.
+- `src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua` – UI voor toggles, loop-kans en basis HUD.
 
 > Tip: Je kunt ook server-only wisselen door `State.MazeAlgorithm.Value = "PRIM"` in de command bar te zetten.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Wat is nieuw
 - **Server-authoritatieve toggle** tussen `DFS` en `PRIM` via `ReplicatedStorage/State/MazeAlgorithm`.
-- **LoopChance**: stel in welk percentage muren na generatie verwijderd wordt (maakt lussen).
+- **LoopChance**: stel in welk percentage muren na generatie verwijderd wordt (maakt lussen, standaard 1%).
 - **Lobby UI** met knoppen (DFS/PRIM + loop-kans). Client vraagt wissels aan; server valideert en zet de waardes.
 - **MazeGenerator** leest runtime-waardes; valt terug op `RoundConfig` bij ontbreken.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Wat is nieuw
 - **Server-authoritatieve toggle** tussen `DFS` en `PRIM` via `ReplicatedStorage/State/MazeAlgorithm`.
-- **LoopChance**: stel in welk percentage muren na generatie verwijderd wordt (maakt lussen, standaard 1%).
+- **LoopChance**: stel in welk percentage muren na generatie verwijderd wordt (maakt lussen, standaard 5%).
 - **Lobby UI** met knoppen (DFS/PRIM + loop-kans). Client vraagt wissels aan; server valideert en zet de waardes.
 - **MazeGenerator** leest runtime-waardes; valt terug op `RoundConfig` bij ontbreken.
 

--- a/default.project.json
+++ b/default.project.json
@@ -25,6 +25,9 @@
         "SetMazeAlgorithm": {
           "$className": "RemoteEvent"
         },
+        "SetLoopChance": {
+          "$className": "RemoteEvent"
+        },
         "InventoryUpdate": {
           "$className": "RemoteEvent"
         },
@@ -44,6 +47,12 @@
           "$className": "StringValue",
           "$properties": {
             "Value": "DFS"
+          }
+        },
+        "LoopChance": {
+          "$className": "NumberValue",
+          "$properties": {
+            "Value": 0
           }
         },
         "Phase": {

--- a/default.project.json
+++ b/default.project.json
@@ -52,7 +52,7 @@
         "LoopChance": {
           "$className": "NumberValue",
           "$properties": {
-            "Value": 0
+            "Value": 0.01
           }
         },
         "Phase": {

--- a/default.project.json
+++ b/default.project.json
@@ -52,7 +52,7 @@
         "LoopChance": {
           "$className": "NumberValue",
           "$properties": {
-            "Value": 0.01
+            "Value": 0.05
           }
         },
         "Phase": {

--- a/src/ReplicatedStorage/Modules/MazeGenerator.lua
+++ b/src/ReplicatedStorage/Modules/MazeGenerator.lua
@@ -5,9 +5,6 @@ local MazeGenerator = {}
 
 local function carveLoops(grid, width, height, chance)
         chance = math.clamp(chance or 0, 0, 1)
-        if chance <= 0 then
-                return
-        end
 
         local candidates = {}
         local removalCount = 0
@@ -25,6 +22,13 @@ local function carveLoops(grid, width, height, chance)
         end
 
         if #candidates == 0 then
+                print("[MazeGenerator] Loop carving skipped: geen kandidaten gevonden.")
+                return
+        end
+
+        if chance <= 0 then
+                print(('[MazeGenerator] Loop carving uitgeschakeld (kans=%.2f, kandidaten=%d)')
+                        :format(chance, #candidates))
                 return
         end
 

--- a/src/ReplicatedStorage/Modules/MazeGenerator.lua
+++ b/src/ReplicatedStorage/Modules/MazeGenerator.lua
@@ -128,7 +128,7 @@ function MazeGenerator.Generate(width, height)
         -- Server-authoritatieve bron: ReplicatedStorage.State.MazeAlgorithm (StringValue)
         local stateFolder = game.ReplicatedStorage:FindFirstChild("State")
         local algo = Config.MazeAlgorithm
-        local loopChance = Config.LoopChance or 0.01
+        local loopChance = Config.LoopChance or 0.05
         if stateFolder and stateFolder:FindFirstChild("MazeAlgorithm") then
                 algo = stateFolder.MazeAlgorithm.Value or algo
         end

--- a/src/ReplicatedStorage/Modules/MazeGenerator.lua
+++ b/src/ReplicatedStorage/Modules/MazeGenerator.lua
@@ -128,7 +128,7 @@ function MazeGenerator.Generate(width, height)
         -- Server-authoritatieve bron: ReplicatedStorage.State.MazeAlgorithm (StringValue)
         local stateFolder = game.ReplicatedStorage:FindFirstChild("State")
         local algo = Config.MazeAlgorithm
-        local loopChance = Config.LoopChance or 0
+        local loopChance = Config.LoopChance or 0.01
         if stateFolder and stateFolder:FindFirstChild("MazeAlgorithm") then
                 algo = stateFolder.MazeAlgorithm.Value or algo
         end

--- a/src/ReplicatedStorage/Modules/MazeGenerator.lua
+++ b/src/ReplicatedStorage/Modules/MazeGenerator.lua
@@ -10,6 +10,7 @@ local function carveLoops(grid, width, height, chance)
         end
 
         local candidates = {}
+        local removalCount = 0
         for x = 1, width do
                 for y = 1, height do
                         local cell = grid[x][y]
@@ -35,9 +36,13 @@ local function carveLoops(grid, width, height, chance)
                         if a and b then
                                 a.walls[wall.dir] = false
                                 b.walls[wall.opp] = false
+                                removalCount = removalCount + 1
                         end
                 end
         end
+
+        print(('[MazeGenerator] Removed %d loop walls out of %d candidates (chance=%.2f)')
+                :format(removalCount, #candidates, chance))
 end
 
 local function newGrid(w, h)

--- a/src/ReplicatedStorage/Modules/RoundConfig.lua
+++ b/src/ReplicatedStorage/Modules/RoundConfig.lua
@@ -26,5 +26,7 @@ local Config = {
 
         -- Default algoritme (server kan runtime wisselen via State.MazeAlgorithm)
         MazeAlgorithm = "DFS", -- "DFS" of "PRIM"
+        -- Kans (0-1) dat een bestaande muur na generatie alsnog wordt verwijderd om lussen te maken.
+        LoopChance = 0,
 }
 return Config

--- a/src/ReplicatedStorage/Modules/RoundConfig.lua
+++ b/src/ReplicatedStorage/Modules/RoundConfig.lua
@@ -27,6 +27,6 @@ local Config = {
         -- Default algoritme (server kan runtime wisselen via State.MazeAlgorithm)
         MazeAlgorithm = "DFS", -- "DFS" of "PRIM"
         -- Kans (0-1) dat een bestaande muur na generatie alsnog wordt verwijderd om lussen te maken.
-        LoopChance = 0,
+        LoopChance = 0.01,
 }
 return Config

--- a/src/ReplicatedStorage/Modules/RoundConfig.lua
+++ b/src/ReplicatedStorage/Modules/RoundConfig.lua
@@ -27,6 +27,6 @@ local Config = {
         -- Default algoritme (server kan runtime wisselen via State.MazeAlgorithm)
         MazeAlgorithm = "DFS", -- "DFS" of "PRIM"
         -- Kans (0-1) dat een bestaande muur na generatie alsnog wordt verwijderd om lussen te maken.
-        LoopChance = 0.01,
+        LoopChance = 0.05,
 }
 return Config

--- a/src/ServerScriptService/AlgorithmService.server.lua
+++ b/src/ServerScriptService/AlgorithmService.server.lua
@@ -2,12 +2,23 @@
 local Replicated = game:GetService("ReplicatedStorage")
 local Remotes = Replicated:FindFirstChild("Remotes")
 local SetMazeAlgorithm = Remotes:FindFirstChild("SetMazeAlgorithm")
+local SetLoopChance = Remotes:FindFirstChild("SetLoopChance")
 local State = Replicated:FindFirstChild("State")
 local valid = { DFS = true, PRIM = true }
 
 SetMazeAlgorithm.OnServerEvent:Connect(function(plr, algo)
-	if typeof(algo) ~= "string" then return end
-	algo = string.upper(algo)
-	if not valid[algo] then return end
-	State.MazeAlgorithm.Value = algo
+        if typeof(algo) ~= "string" then return end
+        algo = string.upper(algo)
+        if not valid[algo] then return end
+        State.MazeAlgorithm.Value = algo
 end)
+
+if SetLoopChance and State and State:FindFirstChild("LoopChance") then
+        local loopValue = State:FindFirstChild("LoopChance")
+        SetLoopChance.OnServerEvent:Connect(function(_, chance)
+                if typeof(chance) ~= "number" then
+                        return
+                end
+                loopValue.Value = math.clamp(chance, 0, 1)
+        end)
+end

--- a/src/ServerScriptService/GameManager.server.lua
+++ b/src/ServerScriptService/GameManager.server.lua
@@ -22,7 +22,7 @@ local State = Replicated:FindFirstChild("State") or Instance.new("Folder", Repli
 local algoValue = State:FindFirstChild("MazeAlgorithm") or Instance.new("StringValue", State)
 algoValue.Name = "MazeAlgorithm"; algoValue.Value = "DFS"
 local loopChanceValue = State:FindFirstChild("LoopChance") or Instance.new("NumberValue", State)
-loopChanceValue.Name = "LoopChance"; loopChanceValue.Value = Config.LoopChance or 0
+loopChanceValue.Name = "LoopChance"; loopChanceValue.Value = Config.LoopChance or 0.01
 
 local mazeFolder = Workspace:FindFirstChild("Maze") or Instance.new("Folder", Workspace); mazeFolder.Name = "Maze"
 local spawns = Workspace:FindFirstChild("Spawns") or Instance.new("Folder", Workspace); spawns.Name = "Spawns"

--- a/src/ServerScriptService/GameManager.server.lua
+++ b/src/ServerScriptService/GameManager.server.lua
@@ -3,6 +3,8 @@ local Players = game:GetService("Players")
 local ServerStorage = game:GetService("ServerStorage")
 local Workspace = game:GetService("Workspace")
 
+local Config = require(Replicated.Modules.RoundConfig)
+
 -- Ensure folders/remotes exist for standalone play or Rojo runtime
 local Remotes = Replicated:FindFirstChild("Remotes") or Instance.new("Folder", Replicated); Remotes.Name = "Remotes"
 local function ensureRemote(name)
@@ -54,7 +56,6 @@ if not prefabs:FindFirstChild("Door") then
 	door.PrimaryPart = part
 end
 
-local Config = require(Replicated.Modules.RoundConfig)
 local MazeGen = require(Replicated.Modules.MazeGenerator)
 local MazeBuilder = require(Replicated.Modules.MazeBuilder)
 local ANIM_DURATION = 12

--- a/src/ServerScriptService/GameManager.server.lua
+++ b/src/ServerScriptService/GameManager.server.lua
@@ -22,7 +22,7 @@ local State = Replicated:FindFirstChild("State") or Instance.new("Folder", Repli
 local algoValue = State:FindFirstChild("MazeAlgorithm") or Instance.new("StringValue", State)
 algoValue.Name = "MazeAlgorithm"; algoValue.Value = "DFS"
 local loopChanceValue = State:FindFirstChild("LoopChance") or Instance.new("NumberValue", State)
-loopChanceValue.Name = "LoopChance"; loopChanceValue.Value = Config.LoopChance or 0.01
+loopChanceValue.Name = "LoopChance"; loopChanceValue.Value = Config.LoopChance or 0.05
 
 local mazeFolder = Workspace:FindFirstChild("Maze") or Instance.new("Folder", Workspace); mazeFolder.Name = "Maze"
 local spawns = Workspace:FindFirstChild("Spawns") or Instance.new("Folder", Workspace); spawns.Name = "Spawns"

--- a/src/ServerScriptService/GameManager.server.lua
+++ b/src/ServerScriptService/GameManager.server.lua
@@ -14,10 +14,13 @@ local RoundState = ensureRemote("RoundState")
 local Countdown = ensureRemote("Countdown")
 ensureRemote("Pickup"); ensureRemote("DoorOpened")
 ensureRemote("SetMazeAlgorithm")
+ensureRemote("SetLoopChance")
 
 local State = Replicated:FindFirstChild("State") or Instance.new("Folder", Replicated); State.Name = "State"
 local algoValue = State:FindFirstChild("MazeAlgorithm") or Instance.new("StringValue", State)
 algoValue.Name = "MazeAlgorithm"; algoValue.Value = "DFS"
+local loopChanceValue = State:FindFirstChild("LoopChance") or Instance.new("NumberValue", State)
+loopChanceValue.Name = "LoopChance"; loopChanceValue.Value = Config.LoopChance or 0
 
 local mazeFolder = Workspace:FindFirstChild("Maze") or Instance.new("Folder", Workspace); mazeFolder.Name = "Maze"
 local spawns = Workspace:FindFirstChild("Spawns") or Instance.new("Folder", Workspace); spawns.Name = "Spawns"

--- a/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
@@ -40,7 +40,7 @@ local function getLoopChance()
         if loopChanceValue and typeof(loopChanceValue.Value) == "number" then
                 return loopChanceValue.Value
         end
-        return RoundConfig.LoopChance or 0
+        return RoundConfig.LoopChance or 0.01
 end
 
 local function updateLoopLabel()

--- a/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
@@ -40,7 +40,7 @@ local function getLoopChance()
         if loopChanceValue and typeof(loopChanceValue.Value) == "number" then
                 return loopChanceValue.Value
         end
-        return RoundConfig.LoopChance or 0.01
+        return RoundConfig.LoopChance or 0.05
 end
 
 local function updateLoopLabel()


### PR DESCRIPTION
## Summary
- add a LoopChance setting that removes extra maze walls after generation to create optional loops
- expose the loop chance to the lobby UI and server state so hosts can tweak it at runtime
- document the new configuration and ensure remotes/state instances exist in the default project

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1a743e5ec83228f7888c8a059c7e9