### PR TITLE
Create dedicated exit room outside maze

### DIFF
--- a/src/ServerScriptService/GameManager.server.lua
+++ b/src/ServerScriptService/GameManager.server.lua
@@ -28,6 +28,66 @@ local lobbyBase = spawns:FindFirstChild("LobbyBase") or Instance.new("Part", spa
 
 -- Exit pad
 local exitPad = spawns:FindFirstChild("ExitPad") or Instance.new("Part", spawns); exitPad.Name = "ExitPad"; exitPad.Anchored = true; exitPad.Size = Vector3.new(4,1,4)
+local exitRoom = spawns:FindFirstChild("ExitRoom") or Instance.new("Model", spawns); exitRoom.Name = "ExitRoom"
+
+local EXIT_ROOM_WIDTH_CELLS = 2
+local EXIT_ROOM_DEPTH_CELLS = 1.5
+local EXIT_DOOR_CLEARANCE = 6
+
+local function ensureExitRoomPart(name)
+        local part = exitRoom:FindFirstChild(name)
+        if not part then
+                part = Instance.new("Part")
+                part.Name = name
+                part.Anchored = true
+                part.CanCollide = true
+                part.Parent = exitRoom
+        end
+        part.Material = Enum.Material.Concrete
+        part.Color = Color3.fromRGB(60, 60, 60)
+        part.Transparency = 0
+        part.Reflectance = 0
+        return part
+end
+
+local function layoutExitRoom()
+        local mazeWidth = Config.GridWidth * Config.CellSize
+        local mazeDepth = Config.GridHeight * Config.CellSize
+        local roomWidth = Config.CellSize * EXIT_ROOM_WIDTH_CELLS
+        local roomDepth = Config.CellSize * EXIT_ROOM_DEPTH_CELLS
+        local wallHeight = Config.WallHeight
+
+        local centerX = mazeWidth - (Config.CellSize / 2)
+        local centerZ = mazeDepth + (roomDepth / 2)
+
+        local floor = ensureExitRoomPart("Floor")
+        floor.Size = Vector3.new(roomWidth, 1, roomDepth)
+        floor.Position = Vector3.new(centerX, 0, centerZ)
+
+        local northWall = ensureExitRoomPart("WallNorth")
+        northWall.Size = Vector3.new(roomWidth, wallHeight, 1)
+        northWall.CFrame = CFrame.new(centerX, wallHeight / 2, mazeDepth + roomDepth)
+
+        local eastWall = ensureExitRoomPart("WallEast")
+        eastWall.Size = Vector3.new(1, wallHeight, roomDepth)
+        eastWall.CFrame = CFrame.new(centerX + roomWidth / 2, wallHeight / 2, centerZ)
+
+        local westWall = ensureExitRoomPart("WallWest")
+        westWall.Size = Vector3.new(1, wallHeight, roomDepth)
+        westWall.CFrame = CFrame.new(centerX - roomWidth / 2, wallHeight / 2, centerZ)
+
+        local maxOpening = math.max(roomWidth - 2, 2)
+        local opening = math.clamp(EXIT_DOOR_CLEARANCE, 2, maxOpening)
+        local sideWidth = math.max((roomWidth - opening) / 2, 0.5)
+
+        local southLeft = ensureExitRoomPart("WallSouthLeft")
+        southLeft.Size = Vector3.new(sideWidth, wallHeight, 1)
+        southLeft.CFrame = CFrame.new(centerX - (opening / 2 + southLeft.Size.X / 2), wallHeight / 2, mazeDepth)
+
+        local southRight = ensureExitRoomPart("WallSouthRight")
+        southRight.Size = Vector3.new(sideWidth, wallHeight, 1)
+        southRight.CFrame = CFrame.new(centerX + (opening / 2 + southRight.Size.X / 2), wallHeight / 2, mazeDepth)
+end
 
 -- Prefabs
 local prefabs = ServerStorage:FindFirstChild("Prefabs") or Instance.new("Folder", ServerStorage); prefabs.Name = "Prefabs"
@@ -129,7 +189,23 @@ local function placeExit()
                 exitTouchedConnection:Disconnect()
                 exitTouchedConnection = nil
         end
-        exitPad.Position = Vector3.new(Config.GridWidth * Config.CellSize - (Config.CellSize/2), 1, Config.GridHeight * Config.CellSize - (Config.CellSize/2))
+        layoutExitRoom()
+
+        local mazeWidth = Config.GridWidth * Config.CellSize
+        local mazeDepth = Config.GridHeight * Config.CellSize
+
+        local exitRoomDepth = Config.CellSize * EXIT_ROOM_DEPTH_CELLS
+        local exitPadZ = mazeDepth + exitRoomDepth - (Config.CellSize / 2)
+        local exitPadX = mazeWidth - (Config.CellSize / 2)
+
+        exitPad.Position = Vector3.new(exitPadX, 1, exitPadZ)
+
+        local topWallName = string.format("W_%d_%d_S", Config.GridWidth, Config.GridHeight)
+        local northWall = mazeFolder:FindFirstChild(topWallName)
+        if northWall then
+                northWall:Destroy()
+        end
+
         exitTouchedConnection = exitPad.Touched:Connect(function(hit)
                 local humanoid = hit.Parent and hit.Parent:FindFirstChildOfClass("Humanoid")
                 if humanoid then

--- a/src/ServerScriptService/GameManager.server.lua
+++ b/src/ServerScriptService/GameManager.server.lua
@@ -3,6 +3,10 @@ local Players = game:GetService("Players")
 local ServerStorage = game:GetService("ServerStorage")
 local Workspace = game:GetService("Workspace")
 
+local Config = require(Replicated.Modules.RoundConfig)
+local MazeGen = require(Replicated.Modules.MazeGenerator)
+local MazeBuilder = require(Replicated.Modules.MazeBuilder)
+
 -- Ensure folders/remotes exist for standalone play or Rojo runtime
 local Remotes = Replicated:FindFirstChild("Remotes") or Instance.new("Folder", Replicated); Remotes.Name = "Remotes"
 local function ensureRemote(name)
@@ -87,6 +91,8 @@ local function layoutExitRoom()
         local southRight = ensureExitRoomPart("WallSouthRight")
         southRight.Size = Vector3.new(sideWidth, wallHeight, 1)
         southRight.CFrame = CFrame.new(centerX + (opening / 2 + southRight.Size.X / 2), wallHeight / 2, mazeDepth)
+
+        exitPad.Position = Vector3.new(centerX, 1, mazeDepth + roomDepth - (Config.CellSize / 2))
 end
 
 -- Prefabs
@@ -111,9 +117,6 @@ if not prefabs:FindFirstChild("Door") then
 	door.PrimaryPart = part
 end
 
-local Config = require(Replicated.Modules.RoundConfig)
-local MazeGen = require(Replicated.Modules.MazeGenerator)
-local MazeBuilder = require(Replicated.Modules.MazeBuilder)
 local ANIM_DURATION = 12
 local POST_ENEMY_DELAY = 3
 
@@ -191,15 +194,6 @@ local function placeExit()
         end
         layoutExitRoom()
 
-        local mazeWidth = Config.GridWidth * Config.CellSize
-        local mazeDepth = Config.GridHeight * Config.CellSize
-
-        local exitRoomDepth = Config.CellSize * EXIT_ROOM_DEPTH_CELLS
-        local exitPadZ = mazeDepth + exitRoomDepth - (Config.CellSize / 2)
-        local exitPadX = mazeWidth - (Config.CellSize / 2)
-
-        exitPad.Position = Vector3.new(exitPadX, 1, exitPadZ)
-
         local topWallName = string.format("W_%d_%d_S", Config.GridWidth, Config.GridHeight)
         local northWall = mazeFolder:FindFirstChild(topWallName)
         if northWall then
@@ -229,6 +223,7 @@ local function runRound()
         MazeBuilder.Clear(mazeFolder)
         local grid = MazeGen.Generate(Config.GridWidth, Config.GridHeight)
         MazeBuilder.BuildFullGrid(Config.GridWidth, Config.GridHeight, Config.CellSize, Config.WallHeight, prefabs, mazeFolder)
+        layoutExitRoom()
         MazeBuilder.AnimateRemoveWalls(grid, mazeFolder, math.max(Config.PrepTime, 1))
 
         for t = Config.PrepTime, 1, -1 do

--- a/src/ServerScriptService/KeyDoorService.server.lua
+++ b/src/ServerScriptService/KeyDoorService.server.lua
@@ -373,9 +373,19 @@ _G.KeyDoor_OnRoundStart = function()
     end
     local door = prefabs.Door:Clone()
     door.Name = "ExitDoor"
-    local rx = Config.GridWidth
-    local ry = Config.GridHeight - 1
-    door:PivotTo(CFrame.new(rx * Config.CellSize - (Config.CellSize / 2), 4, ry * Config.CellSize - (Config.CellSize / 2)))
+    local panel = door:FindFirstChild("Panel") or door.PrimaryPart
+    if door.PrimaryPart == nil and panel then
+        door.PrimaryPart = panel
+    end
+
+    local doorHeight = 4
+    if panel and panel:IsA("BasePart") then
+        doorHeight = panel.Size.Y / 2
+    end
+
+    local doorX = Config.GridWidth * Config.CellSize - (Config.CellSize / 2)
+    local doorZ = Config.GridHeight * Config.CellSize
+    door:PivotTo(CFrame.new(doorX, doorHeight, doorZ))
     door.Parent = workspace.Maze
     local locked = door:FindFirstChild("Locked")
     if not locked then


### PR DESCRIPTION
## Summary
- add reusable exit room geometry that sits just outside the maze layout
- reposition the exit pad into the new room and clear the maze wall section used for the door
- move the exit door onto the maze boundary so it opens into the new exterior room

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1aedbf8e8832294cc85f20113da61