### PR TITLE
Mirror Maze Rush keys into Roblox backpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@
 - `src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua` – UI voor toggles, loop-kans en basis HUD.
 
 > Tip: Je kunt ook server-only wisselen door `State.MazeAlgorithm.Value = "PRIM"` in de command bar te zetten.
+
+## Inventory en Roblox-backpack
+Maze Rush houdt de inventaris server-side bij in `InventoryService` en deelt die service via `_G.Inventory` zodat bijvoorbeeld `KeyDoorService` kan valideren of iemand een sleutel bezit. Vanaf nu spiegelt de service ook automatisch het sleutel-aantal naar de standaard Roblox-backpack: voor elke sleutel verschijnt er een `Maze Key`-tool (zonder handle) in de backpack van de speler.
+
+De custom HUD in `ClientUI.client.lua` blijft nuttig voor bediening van Maze Rush-specifieke toggles, maar spelers kunnen nu hun sleutels beheren zoals elke andere Roblox-tool – inclusief ondersteuning voor controller/mobile dankzij de standaard backpack UI. Wanneer een sleutel wordt gebruikt of gereset, verwijdert `InventoryService` het overeenkomstige tool-item zodat de backpack altijd de serverstatus volgt.

--- a/src/ServerScriptService/InventoryService.server.lua
+++ b/src/ServerScriptService/InventoryService.server.lua
@@ -6,16 +6,87 @@ local InventoryUpdate = Remotes:WaitForChild("InventoryUpdate")
 
 local Inventory = {}  -- [player.UserId] = { keys = int }
 
+local KEY_TOOL_ATTRIBUTE = "MazeRushKeyTool"
+local KEY_TOOL_NAME = "Maze Key"
+local KEY_TOOL_TOOLTIP = "Gebruik deze sleutel om deuren in Maze Rush te openen."
+
+local function gatherKeyTools(plr)
+        local containers = {}
+        local backpack = plr:FindFirstChildOfClass("Backpack")
+        if backpack then
+                table.insert(containers, backpack)
+        end
+
+        local character = plr.Character
+        if character then
+                table.insert(containers, character)
+        end
+
+        local keyTools = {}
+        for _, container in ipairs(containers) do
+                for _, child in ipairs(container:GetChildren()) do
+                        if child:IsA("Tool") and child:GetAttribute(KEY_TOOL_ATTRIBUTE) then
+                                table.insert(keyTools, child)
+                        end
+                end
+        end
+
+        return keyTools, backpack
+end
+
+local function syncKeyTools(plr)
+        if not plr or not plr.Parent then
+                return
+        end
+
+        local inv = Inventory[plr.UserId]
+        if not inv then
+                return
+        end
+
+        local desired = math.max(0, inv.keys or 0)
+        local existingTools, backpack = gatherKeyTools(plr)
+        local total = #existingTools
+
+        if total > desired then
+                for index = desired + 1, total do
+                        local tool = existingTools[index]
+                        if tool then
+                                tool:Destroy()
+                        end
+                end
+        elseif total < desired then
+                backpack = backpack or plr:FindFirstChildOfClass("Backpack")
+                if not backpack then
+                        task.defer(function()
+                                syncKeyTools(plr)
+                        end)
+                        return
+                end
+
+                for _ = total + 1, desired do
+                        local tool = Instance.new("Tool")
+                        tool.Name = KEY_TOOL_NAME
+                        tool.RequiresHandle = false
+                        tool.CanBeDropped = false
+                        tool:SetAttribute(KEY_TOOL_ATTRIBUTE, true)
+                        tool.ToolTip = KEY_TOOL_TOOLTIP
+                        tool.Parent = backpack
+                end
+        end
+end
+
 local function ensure(plr)
-	if not Inventory[plr.UserId] then
-		Inventory[plr.UserId] = { keys = 0 }
-	end
-	return Inventory[plr.UserId]
+        if not Inventory[plr.UserId] then
+                Inventory[plr.UserId] = { keys = 0 }
+        end
+        return Inventory[plr.UserId]
 end
 
 local function pushClient(plr)
-	local inv = ensure(plr)
-	InventoryUpdate:FireClient(plr, { keys = inv.keys })
+        local inv = ensure(plr)
+        InventoryUpdate:FireClient(plr, { keys = inv.keys })
+        syncKeyTools(plr)
 end
 
 local Service = {}
@@ -68,8 +139,22 @@ _G.Inventory = Service
 shared.Inventory = Service
 
 Players.PlayerAdded:Connect(function(plr)
-	ensure(plr)
-	pushClient(plr)
+        ensure(plr)
+        pushClient(plr)
+
+        local function trySync()
+                syncKeyTools(plr)
+        end
+
+        plr.ChildAdded:Connect(function(child)
+                if child:IsA("Backpack") then
+                        task.defer(trySync)
+                end
+        end)
+
+        plr.CharacterAdded:Connect(function()
+                task.defer(trySync)
+        end)
 end)
 
 Players.PlayerRemoving:Connect(function(plr)


### PR DESCRIPTION
## Summary
- sync the server-side key inventory with the Roblox backpack by creating Maze Key tools for each key a player owns
- keep the backpack state updated as keys are earned, spent, or reset by watching player backpack/character lifecycle events
- document the new backpack mirroring so players know to use the standard Roblox inventory UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27fde8ae083228bbfadc0d8bb0584