### PR TITLE
Add lobby previews and highlight updates

### DIFF
--- a/src/ReplicatedStorage/Modules/ThemeConfig.lua
+++ b/src/ReplicatedStorage/Modules/ThemeConfig.lua
@@ -17,6 +17,18 @@ local ThemeList = {
                 exitColor = Color3.fromRGB(255, 180, 75),
                 exitMaterial = Enum.Material.Neon,
                 exitTransparency = 0,
+                lobby = {
+                        assetFolderPath = {"LobbyAssets", "Spooky"},
+                        previewModels = {"PreviewStand"},
+                        ambientSound = "Ambient",
+                        lighting = {
+                                Ambient = Color3.fromRGB(15, 10, 25),
+                                OutdoorAmbient = Color3.fromRGB(30, 20, 50),
+                                FogColor = Color3.fromRGB(30, 25, 45),
+                                FogEnd = 120,
+                                Brightness = 1.5,
+                        },
+                },
         },
         {
                 id = "Jungle",
@@ -34,6 +46,18 @@ local ThemeList = {
                 exitColor = Color3.fromRGB(245, 215, 110),
                 exitMaterial = Enum.Material.Neon,
                 exitTransparency = 0,
+                lobby = {
+                        assetFolderPath = {"LobbyAssets", "Jungle"},
+                        previewModels = {"PreviewStand"},
+                        ambientSound = "Wildlife",
+                        lighting = {
+                                Ambient = Color3.fromRGB(35, 60, 35),
+                                OutdoorAmbient = Color3.fromRGB(70, 100, 70),
+                                FogColor = Color3.fromRGB(80, 120, 80),
+                                FogEnd = 150,
+                                Brightness = 2.2,
+                        },
+                },
         },
         {
                 id = "Frost",
@@ -51,6 +75,18 @@ local ThemeList = {
                 exitColor = Color3.fromRGB(255, 255, 255),
                 exitMaterial = Enum.Material.Glass,
                 exitTransparency = 0.1,
+                lobby = {
+                        assetFolderPath = {"LobbyAssets", "Frost"},
+                        previewModels = {"PreviewStand"},
+                        ambientSound = "Wind",
+                        lighting = {
+                                Ambient = Color3.fromRGB(160, 190, 255),
+                                OutdoorAmbient = Color3.fromRGB(200, 230, 255),
+                                FogColor = Color3.fromRGB(215, 235, 255),
+                                FogEnd = 180,
+                                Brightness = 2.8,
+                        },
+                },
         },
         {
                 id = "Glaze",
@@ -66,6 +102,18 @@ local ThemeList = {
                 exitColor = Color3.fromRGB(255, 255, 255),
                 exitMaterial = Enum.Material.Neon,
                 exitTransparency = 0.25,
+                lobby = {
+                        assetFolderPath = {"LobbyAssets", "Glaze"},
+                        previewModels = {"PreviewStand"},
+                        ambientSound = "Chimes",
+                        lighting = {
+                                Ambient = Color3.fromRGB(205, 230, 255),
+                                OutdoorAmbient = Color3.fromRGB(235, 245, 255),
+                                FogColor = Color3.fromRGB(255, 255, 255),
+                                FogEnd = 220,
+                                Brightness = 3.2,
+                        },
+                },
         },
 }
 
@@ -83,6 +131,14 @@ ThemeConfig.Order = ThemeOrder
 
 function ThemeConfig.Get(themeId)
         return ThemeMap[themeId]
+end
+
+function ThemeConfig.GetLobbyAssets(themeId)
+        local theme = ThemeMap[themeId]
+        if theme then
+                return theme.lobby
+        end
+        return nil
 end
 
 local function cloneIds()

--- a/src/ServerScriptService/LobbyPreviewService.server.lua
+++ b/src/ServerScriptService/LobbyPreviewService.server.lua
@@ -466,5 +466,3 @@ end
 ensurePreviewsExist()
 ThemeValue.Changed:Connect(onThemeChanged)
 onThemeChanged()
-
-*** End of File ***

--- a/src/ServerScriptService/LobbyPreviewService.server.lua
+++ b/src/ServerScriptService/LobbyPreviewService.server.lua
@@ -1,0 +1,185 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Workspace = game:GetService("Workspace")
+local Lighting = game:GetService("Lighting")
+
+local Modules = ReplicatedStorage:WaitForChild("Modules")
+local ThemeConfig = require(Modules.ThemeConfig)
+
+local State = ReplicatedStorage:WaitForChild("State")
+local ThemeValue = State:WaitForChild("Theme")
+
+local lobbyFolder = Workspace:WaitForChild("Lobby")
+local previewContainer = lobbyFolder:FindFirstChild("PreviewStands")
+if not previewContainer then
+        previewContainer = Instance.new("Folder")
+        previewContainer.Name = "PreviewStands"
+        previewContainer.Parent = lobbyFolder
+end
+
+local LIGHTING_PROPERTIES = {
+        "Ambient",
+        "OutdoorAmbient",
+        "FogColor",
+        "FogStart",
+        "FogEnd",
+        "Brightness",
+        "ColorShift_Top",
+        "ColorShift_Bottom",
+        "ClockTime",
+}
+
+local defaultLighting = {}
+for _, prop in ipairs(LIGHTING_PROPERTIES) do
+        defaultLighting[prop] = Lighting[prop]
+end
+
+local activeModels = {}
+local activeAmbientSound = nil
+local currentThemeId = nil
+
+local function resolvePath(path)
+        if typeof(path) == "Instance" then
+                return path
+        end
+        local current = ReplicatedStorage
+        if type(path) == "string" then
+                for segment in string.gmatch(path, "[^/]+") do
+                        if not current then
+                                return nil
+                        end
+                        current = current:FindFirstChild(segment)
+                end
+                return current
+        elseif type(path) == "table" then
+                for _, segment in ipairs(path) do
+                        if typeof(segment) == "Instance" then
+                                current = segment
+                        else
+                                current = current and current:FindFirstChild(segment)
+                        end
+                        if not current then
+                                return nil
+                        end
+                end
+                return current
+        end
+        return nil
+end
+
+local function clearPreview()
+        for _, model in ipairs(activeModels) do
+                if model and model.Parent then
+                        model:Destroy()
+                end
+        end
+        table.clear(activeModels)
+        if activeAmbientSound then
+                activeAmbientSound:Stop()
+                activeAmbientSound:Destroy()
+                activeAmbientSound = nil
+        end
+end
+
+local function applyLightingOverrides(overrides)
+        for _, prop in ipairs(LIGHTING_PROPERTIES) do
+                local value = overrides and overrides[prop]
+                if value == nil then
+                        value = defaultLighting[prop]
+                end
+                local ok, err = pcall(function()
+                        Lighting[prop] = value
+                end)
+                if not ok then
+                        warn(string.format("[LobbyPreviewService] Unable to set Lighting.%s: %s", tostring(prop), tostring(err)))
+                end
+        end
+end
+
+local function loadPreviewForTheme(themeId)
+        if currentThemeId == themeId then
+                return
+        end
+        currentThemeId = themeId
+
+        clearPreview()
+
+        local themeAssets = ThemeConfig.GetLobbyAssets(themeId)
+        if not themeAssets then
+                applyLightingOverrides(nil)
+                return
+        end
+
+        local assetFolder = resolvePath(themeAssets.assetFolderPath or themeAssets.assetFolder or themeAssets.folder)
+        if not assetFolder then
+                warn(string.format("[LobbyPreviewService] Asset folder missing for theme '%s'", tostring(themeId)))
+                applyLightingOverrides(themeAssets.lighting)
+                return
+        end
+
+        local previewList = {}
+        if themeAssets.previewModels then
+                if type(themeAssets.previewModels) == "table" then
+                        for _, item in ipairs(themeAssets.previewModels) do
+                                table.insert(previewList, item)
+                        end
+                elseif type(themeAssets.previewModels) == "string" then
+                        table.insert(previewList, themeAssets.previewModels)
+                end
+        end
+        if #previewList == 0 then
+                for _, child in ipairs(assetFolder:GetChildren()) do
+                        if child:IsA("Model") or child:IsA("BasePart") then
+                                table.insert(previewList, child.Name)
+                        end
+                end
+        end
+
+        for _, previewName in ipairs(previewList) do
+                local source = assetFolder:FindFirstChild(previewName)
+                if source then
+                        local clone = source:Clone()
+                        clone.Name = string.format("%s_%s", tostring(themeId), source.Name)
+                        clone:SetAttribute("ThemeId", themeId)
+                        clone.Parent = previewContainer
+                        table.insert(activeModels, clone)
+                else
+                        warn(string.format("[LobbyPreviewService] Missing preview '%s' for theme '%s'", tostring(previewName), tostring(themeId)))
+                end
+        end
+
+        if themeAssets.ambientSound then
+                local soundSource
+                if typeof(themeAssets.ambientSound) == "Instance" and themeAssets.ambientSound:IsA("Sound") then
+                        soundSource = themeAssets.ambientSound
+                elseif type(themeAssets.ambientSound) == "string" then
+                        soundSource = assetFolder:FindFirstChild(themeAssets.ambientSound)
+                end
+                if soundSource and soundSource:IsA("Sound") then
+                        local soundClone = soundSource:Clone()
+                        soundClone.Name = string.format("%s_Ambient", tostring(themeId))
+                        soundClone.Parent = previewContainer
+                        soundClone.Looped = true
+                        soundClone.Playing = true
+                        soundClone.Volume = soundClone.Volume > 0 and soundClone.Volume or 0.5
+                        soundClone:Play()
+                        activeAmbientSound = soundClone
+                else
+                        warn(string.format("[LobbyPreviewService] Ambient sound missing for theme '%s'", tostring(themeId)))
+                end
+        end
+
+        applyLightingOverrides(themeAssets.lighting)
+end
+
+local function onThemeChanged()
+        local themeId = ThemeValue.Value
+        if themeId == nil or themeId == "" then
+                themeId = ThemeConfig.Default
+        end
+        loadPreviewForTheme(themeId)
+end
+
+ThemeValue.Changed:Connect(onThemeChanged)
+onThemeChanged()
+
+*** End of File ***

--- a/src/ServerScriptService/LobbyPreviewService.server.lua
+++ b/src/ServerScriptService/LobbyPreviewService.server.lua
@@ -8,12 +8,23 @@ local ThemeConfig = require(Modules.ThemeConfig)
 local State = ReplicatedStorage:WaitForChild("State")
 local ThemeValue = State:WaitForChild("Theme")
 
-local lobbyFolder = Workspace:WaitForChild("Lobby")
+local function ensureLobbyFolder()
+    local lobby = Workspace:FindFirstChild("Lobby")
+    if not lobby then
+        lobby = Instance.new("Folder")
+        lobby.Name = "Lobby"
+        lobby.Parent = Workspace
+    end
+    return lobby
+end
+
+local lobbyFolder = ensureLobbyFolder()
+
 local previewContainer = lobbyFolder:FindFirstChild("PreviewStands")
 if not previewContainer then
-        previewContainer = Instance.new("Folder")
-        previewContainer.Name = "PreviewStands"
-        previewContainer.Parent = lobbyFolder
+    previewContainer = Instance.new("Folder")
+    previewContainer.Name = "PreviewStands"
+    previewContainer.Parent = lobbyFolder
 end
 
 local LIGHTING_PROPERTIES = {
@@ -33,152 +44,426 @@ for _, prop in ipairs(LIGHTING_PROPERTIES) do
         defaultLighting[prop] = Lighting[prop]
 end
 
-local activeModels = {}
-local activeAmbientSound = nil
-local currentThemeId = nil
-
-local function resolvePath(path)
-        if typeof(path) == "Instance" then
-                return path
-        end
-        local current = ReplicatedStorage
-        if type(path) == "string" then
-                for segment in string.gmatch(path, "[^/]+") do
-                        if not current then
-                                return nil
-                        end
-                        current = current:FindFirstChild(segment)
-                end
-                return current
-        elseif type(path) == "table" then
-                for _, segment in ipairs(path) do
-                        if typeof(segment) == "Instance" then
-                                current = segment
-                        else
-                                current = current and current:FindFirstChild(segment)
-                        end
-                        if not current then
-                                return nil
-                        end
-                end
-                return current
-        end
+local function getLobbyBase()
+    local spawns = Workspace:FindFirstChild("Spawns")
+    if not spawns then
         return nil
+    end
+    local lobbyBase = spawns:FindFirstChild("LobbyBase")
+    if lobbyBase and lobbyBase:IsA("BasePart") then
+        return lobbyBase
+    end
+    return nil
 end
 
-local function clearPreview()
-        for _, model in ipairs(activeModels) do
-                if model and model.Parent then
-                        model:Destroy()
+local function computePreviewSlots()
+    local order = ThemeConfig.GetOrderedIds and ThemeConfig.GetOrderedIds() or {}
+    if not order or #order == 0 then
+        order = {}
+        for themeId in pairs(ThemeConfig.Themes) do
+            table.insert(order, themeId)
+        end
+        table.sort(order)
+    end
+    local slots = {}
+    local total = math.max(#order, 1)
+    local lobbyBase = getLobbyBase()
+    local basePosition = Vector3.new(0, 0, 0)
+    local baseHeight = 0
+    local radius = 18
+    if lobbyBase then
+        basePosition = lobbyBase.CFrame.Position
+        baseHeight = lobbyBase.Size.Y * 0.5
+        radius = math.max(12, math.min(lobbyBase.Size.X, lobbyBase.Size.Z) * 0.35)
+    end
+    for index, themeId in ipairs(order) do
+        local angle = ((index - 1) / total) * math.pi * 2
+        local offset = Vector3.new(math.cos(angle) * radius, 0, math.sin(angle) * radius)
+        local heightOffset = baseHeight + 3.2
+        local position = basePosition + offset + Vector3.new(0, heightOffset, 0)
+        slots[themeId] = CFrame.new(position, basePosition + Vector3.new(0, baseHeight + 1.5, 0))
+    end
+    return slots
+end
+
+local previewSlots = computePreviewSlots()
+
+local activePreviews = {}
+local activeAmbientSound = nil
+
+local function createFallbackPreview(themeId)
+    local theme = ThemeConfig.Get(themeId)
+    if not theme then
+        return nil
+    end
+    local stand = Instance.new("Model")
+    stand.Name = string.format("%s_Preview", tostring(themeId))
+    stand:SetAttribute("ThemeId", themeId)
+
+    local base = Instance.new("Part")
+    base.Name = "StandBase"
+    base.Size = Vector3.new(6, 1, 6)
+    base.Anchored = true
+    base.CanCollide = true
+    base.Material = Enum.Material.SmoothPlastic
+    base.Color = theme.lobbyColor or theme.primaryColor or Color3.fromRGB(60, 60, 70)
+    base.Parent = stand
+
+    local column = Instance.new("Part")
+    column.Name = "StandColumn"
+    column.Size = Vector3.new(1.6, 5.2, 1.6)
+    column.Anchored = true
+    column.CanCollide = false
+    column.Material = Enum.Material.Neon
+    column.Color = theme.primaryColor or Color3.fromRGB(255, 255, 255)
+    column.CFrame = CFrame.new(0, 3.1, 0)
+    column.Parent = stand
+
+    local attachment = Instance.new("Attachment")
+    attachment.Name = "PreviewAttachment"
+    attachment.Parent = column
+
+    local particles = Instance.new("ParticleEmitter")
+    particles.Name = "LobbyPreviewParticles"
+    particles.Enabled = false
+    particles.Color = ColorSequence.new(theme.primaryColor or Color3.fromRGB(255, 255, 255))
+    particles.LightEmission = 0.7
+    particles.Size = NumberSequence.new({
+        NumberSequenceKeypoint.new(0, 0.6),
+        NumberSequenceKeypoint.new(1, 0.15),
+    })
+    particles.Lifetime = NumberRange.new(1, 1.5)
+    particles.Rate = 12
+    particles.Speed = NumberRange.new(0.5, 1.2)
+    particles.Parent = attachment
+
+    local light = Instance.new("PointLight")
+    light.Name = "LobbyAccentLight"
+    light.Enabled = false
+    light.Brightness = 2.5
+    light.Range = 16
+    light.Color = theme.primaryColor or Color3.fromRGB(255, 255, 255)
+    light.Parent = column
+
+    local billboard = Instance.new("BillboardGui")
+    billboard.Name = "ThemeBillboard"
+    billboard.Size = UDim2.new(4, 0, 1.6, 0)
+    billboard.StudsOffsetWorldSpace = Vector3.new(0, 3.5, 0)
+    billboard.AlwaysOnTop = true
+    billboard.Parent = column
+
+    local label = Instance.new("TextLabel")
+    label.Name = "ThemeLabel"
+    label.AnchorPoint = Vector2.new(0.5, 0.5)
+    label.Position = UDim2.new(0.5, 0, 0.5, 0)
+    label.Size = UDim2.new(1, 0, 1, 0)
+    label.BackgroundTransparency = 1
+    label.Text = theme.displayName or tostring(themeId)
+    label.TextColor3 = theme.primaryColor or Color3.fromRGB(255, 255, 255)
+    label.TextScaled = true
+    label.Font = Enum.Font.GothamBold
+    label.Parent = billboard
+
+    stand.PrimaryPart = column
+    return stand
+end
+
+local function resolvePath(path)
+    if typeof(path) == "Instance" then
+        return path
+    end
+    local current = ReplicatedStorage
+    if type(path) == "string" then
+        for segment in string.gmatch(path, "[^/]+") do
+            if not current then
+                return nil
+            end
+            current = current:FindFirstChild(segment)
+        end
+        return current
+    elseif type(path) == "table" then
+        for _, segment in ipairs(path) do
+            if typeof(segment) == "Instance" then
+                current = segment
+            else
+                current = current and current:FindFirstChild(segment)
+            end
+            if not current then
+                return nil
+            end
+        end
+        return current
+    end
+    return nil
+end
+
+local function gatherParts(model)
+    local parts = {}
+    for _, descendant in ipairs(model:GetDescendants()) do
+        if descendant:IsA("BasePart") then
+            descendant.Anchored = true
+            table.insert(parts, {
+                instance = descendant,
+                transparency = descendant.Transparency,
+            })
+        end
+    end
+    return parts
+end
+
+local function gatherGuiObjects(model)
+    local guiObjects = {}
+    for _, descendant in ipairs(model:GetDescendants()) do
+        if descendant:IsA("TextLabel") or descendant:IsA("TextButton") then
+            table.insert(guiObjects, {
+                instance = descendant,
+                type = "Text",
+                value = descendant.TextTransparency,
+            })
+        elseif descendant:IsA("ImageLabel") or descendant:IsA("ImageButton") then
+            table.insert(guiObjects, {
+                instance = descendant,
+                type = "Image",
+                value = descendant.ImageTransparency,
+            })
+        end
+    end
+    return guiObjects
+end
+
+local function cloneAmbientSound(themeAssets, assetFolder)
+    if not themeAssets then
+        return nil
+    end
+    local source
+    if themeAssets.ambientSound then
+        if typeof(themeAssets.ambientSound) == "Instance" and themeAssets.ambientSound:IsA("Sound") then
+            source = themeAssets.ambientSound
+        elseif type(themeAssets.ambientSound) == "string" and assetFolder then
+            source = assetFolder:FindFirstChild(themeAssets.ambientSound)
+        end
+    end
+    if source and source:IsA("Sound") then
+        local clone = source:Clone()
+        clone.Looped = true
+        if clone.Volume <= 0 then
+            clone.Volume = 0.5
+        end
+        clone.Playing = false
+        return clone
+    end
+    return nil
+end
+
+local function applyFallbackToContainer(container, themeId)
+    local fallback = createFallbackPreview(themeId)
+    if not fallback then
+        return false
+    end
+    local primary = fallback.PrimaryPart
+    for _, child in ipairs(fallback:GetChildren()) do
+        child.Parent = container
+    end
+    if primary then
+        container.PrimaryPart = primary
+    end
+    fallback:Destroy()
+    return true
+end
+
+local function createPreviewRecord(themeId)
+    local theme = ThemeConfig.Get(themeId)
+    if not theme then
+        return nil
+    end
+    local container = Instance.new("Model")
+    container.Name = string.format("%s_Preview", tostring(themeId))
+    container:SetAttribute("ThemeId", themeId)
+    container.Parent = previewContainer
+
+    local themeAssets = ThemeConfig.GetLobbyAssets(themeId)
+    local assetFolder
+    if themeAssets then
+        assetFolder = resolvePath(themeAssets.assetFolderPath or themeAssets.assetFolder or themeAssets.folder)
+    end
+    local added = false
+    if assetFolder then
+        local previewNames = {}
+        if themeAssets.previewModels then
+            if typeof(themeAssets.previewModels) == "Instance" then
+                table.insert(previewNames, themeAssets.previewModels)
+            elseif type(themeAssets.previewModels) == "table" then
+                for _, value in ipairs(themeAssets.previewModels) do
+                    table.insert(previewNames, value)
                 end
+            elseif type(themeAssets.previewModels) == "string" then
+                table.insert(previewNames, themeAssets.previewModels)
+            end
         end
-        table.clear(activeModels)
-        if activeAmbientSound then
-                activeAmbientSound:Stop()
-                activeAmbientSound:Destroy()
-                activeAmbientSound = nil
+        if themeAssets.previewModel then
+            table.insert(previewNames, themeAssets.previewModel)
         end
+        for _, value in ipairs(previewNames) do
+            local source = value
+            if typeof(source) ~= "Instance" then
+                source = assetFolder:FindFirstChild(tostring(value))
+            end
+            if source then
+                local clone = source:Clone()
+                clone.Parent = container
+                added = true
+            end
+        end
+        if not added then
+            for _, child in ipairs(assetFolder:GetChildren()) do
+                if child:IsA("Model") or child:IsA("BasePart") then
+                    local clone = child:Clone()
+                    clone.Parent = container
+                    added = true
+                end
+            end
+        end
+    end
+
+    if not added then
+        added = applyFallbackToContainer(container, themeId)
+    end
+
+    local parts = gatherParts(container)
+    if not container.PrimaryPart then
+        for _, info in ipairs(parts) do
+            if info.instance:IsA("BasePart") then
+                container.PrimaryPart = info.instance
+                break
+            end
+        end
+    end
+
+    local slot = previewSlots[themeId]
+    if slot then
+        local ok, err = pcall(function()
+            container:PivotTo(slot)
+        end)
+        if not ok then
+            warn(string.format("[LobbyPreviewService] Unable to pivot preview for '%s': %s", tostring(themeId), tostring(err)))
+        end
+    end
+
+    local ambient = cloneAmbientSound(themeAssets, assetFolder)
+    if ambient then
+        ambient.Name = string.format("%s_Ambient", tostring(themeId))
+        ambient.Parent = container
+    end
+
+    local guiObjects = gatherGuiObjects(container)
+
+    return {
+        themeId = themeId,
+        model = container,
+        parts = parts,
+        guiObjects = guiObjects,
+        ambientSound = ambient,
+        ambientVolume = ambient and ambient.Volume or nil,
+        lighting = themeAssets and themeAssets.lighting or nil,
+    }
+end
+
+local function ensurePreviewsExist()
+    for _, themeId in ipairs(ThemeConfig.GetOrderedIds()) do
+        if not activePreviews[themeId] then
+            activePreviews[themeId] = createPreviewRecord(themeId)
+        end
+    end
+    for themeId, record in pairs(activePreviews) do
+        if not record or not record.model or not record.model.Parent then
+            activePreviews[themeId] = createPreviewRecord(themeId)
+        end
+    end
+end
+
+local function setPreviewActive(record, isActive)
+    if not record or not record.model then
+        return
+    end
+    record.model:SetAttribute("PreviewActive", isActive)
+    for _, info in ipairs(record.parts or {}) do
+        local part = info.instance
+        if part and part.Parent then
+            local targetTransparency = info.transparency or 0
+            if not isActive then
+                targetTransparency = math.clamp(targetTransparency + 0.45, 0, 1)
+            end
+            part.Transparency = targetTransparency
+        end
+    end
+    for _, info in ipairs(record.guiObjects or {}) do
+        local gui = info.instance
+        if gui and gui.Parent then
+            if info.type == "Text" then
+                gui.TextTransparency = isActive and (info.value or 0) or math.clamp((info.value or 0) + 0.35, 0, 1)
+            elseif info.type == "Image" then
+                gui.ImageTransparency = isActive and (info.value or 0) or math.clamp((info.value or 0) + 0.35, 0, 1)
+            end
+        end
+    end
+    if record.ambientSound then
+        if isActive then
+            record.ambientSound.Volume = record.ambientVolume or record.ambientSound.Volume
+            record.ambientSound.Playing = true
+            activeAmbientSound = record.ambientSound
+        else
+            record.ambientSound.Playing = false
+        end
+    end
+end
+
+local function clearInactiveAmbient()
+    if activeAmbientSound and activeAmbientSound.Parent then
+        activeAmbientSound.Playing = false
+    end
+    activeAmbientSound = nil
 end
 
 local function applyLightingOverrides(overrides)
-        for _, prop in ipairs(LIGHTING_PROPERTIES) do
-                local value = overrides and overrides[prop]
-                if value == nil then
-                        value = defaultLighting[prop]
-                end
-                local ok, err = pcall(function()
-                        Lighting[prop] = value
-                end)
-                if not ok then
-                        warn(string.format("[LobbyPreviewService] Unable to set Lighting.%s: %s", tostring(prop), tostring(err)))
-                end
+    for _, prop in ipairs(LIGHTING_PROPERTIES) do
+        local value = overrides and overrides[prop]
+        if value == nil then
+            value = defaultLighting[prop]
         end
+        local ok, err = pcall(function()
+            Lighting[prop] = value
+        end)
+        if not ok then
+            warn(string.format("[LobbyPreviewService] Unable to set Lighting.%s: %s", tostring(prop), tostring(err)))
+        end
+    end
 end
 
-local function loadPreviewForTheme(themeId)
-        if currentThemeId == themeId then
-                return
-        end
-        currentThemeId = themeId
-
-        clearPreview()
-
-        local themeAssets = ThemeConfig.GetLobbyAssets(themeId)
-        if not themeAssets then
-                applyLightingOverrides(nil)
-                return
-        end
-
-        local assetFolder = resolvePath(themeAssets.assetFolderPath or themeAssets.assetFolder or themeAssets.folder)
-        if not assetFolder then
-                warn(string.format("[LobbyPreviewService] Asset folder missing for theme '%s'", tostring(themeId)))
-                applyLightingOverrides(themeAssets.lighting)
-                return
-        end
-
-        local previewList = {}
-        if themeAssets.previewModels then
-                if type(themeAssets.previewModels) == "table" then
-                        for _, item in ipairs(themeAssets.previewModels) do
-                                table.insert(previewList, item)
-                        end
-                elseif type(themeAssets.previewModels) == "string" then
-                        table.insert(previewList, themeAssets.previewModels)
-                end
-        end
-        if #previewList == 0 then
-                for _, child in ipairs(assetFolder:GetChildren()) do
-                        if child:IsA("Model") or child:IsA("BasePart") then
-                                table.insert(previewList, child.Name)
-                        end
-                end
-        end
-
-        for _, previewName in ipairs(previewList) do
-                local source = assetFolder:FindFirstChild(previewName)
-                if source then
-                        local clone = source:Clone()
-                        clone.Name = string.format("%s_%s", tostring(themeId), source.Name)
-                        clone:SetAttribute("ThemeId", themeId)
-                        clone.Parent = previewContainer
-                        table.insert(activeModels, clone)
-                else
-                        warn(string.format("[LobbyPreviewService] Missing preview '%s' for theme '%s'", tostring(previewName), tostring(themeId)))
-                end
-        end
-
-        if themeAssets.ambientSound then
-                local soundSource
-                if typeof(themeAssets.ambientSound) == "Instance" and themeAssets.ambientSound:IsA("Sound") then
-                        soundSource = themeAssets.ambientSound
-                elseif type(themeAssets.ambientSound) == "string" then
-                        soundSource = assetFolder:FindFirstChild(themeAssets.ambientSound)
-                end
-                if soundSource and soundSource:IsA("Sound") then
-                        local soundClone = soundSource:Clone()
-                        soundClone.Name = string.format("%s_Ambient", tostring(themeId))
-                        soundClone.Parent = previewContainer
-                        soundClone.Looped = true
-                        soundClone.Playing = true
-                        soundClone.Volume = soundClone.Volume > 0 and soundClone.Volume or 0.5
-                        soundClone:Play()
-                        activeAmbientSound = soundClone
-                else
-                        warn(string.format("[LobbyPreviewService] Ambient sound missing for theme '%s'", tostring(themeId)))
-                end
-        end
-
-        applyLightingOverrides(themeAssets.lighting)
+local function applyTheme(themeId)
+    ensurePreviewsExist()
+    local resolved = themeId
+    if resolved == nil or resolved == "" then
+        resolved = ThemeConfig.Default
+    end
+    clearInactiveAmbient()
+    for id, record in pairs(activePreviews) do
+        setPreviewActive(record, id == resolved)
+    end
+    local activeRecord = activePreviews[resolved]
+    local overrides = activeRecord and activeRecord.lighting
+    if not overrides then
+        local assets = ThemeConfig.GetLobbyAssets(resolved)
+        overrides = assets and assets.lighting or nil
+    end
+    applyLightingOverrides(overrides)
 end
 
 local function onThemeChanged()
-        local themeId = ThemeValue.Value
-        if themeId == nil or themeId == "" then
-                themeId = ThemeConfig.Default
-        end
-        loadPreviewForTheme(themeId)
+    local themeId = ThemeValue.Value
+    applyTheme(themeId)
 end
 
+ensurePreviewsExist()
 ThemeValue.Changed:Connect(onThemeChanged)
 onThemeChanged()
 

--- a/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
@@ -11,6 +11,7 @@ local AliveStatus = Remotes:WaitForChild("AliveStatus")
 local PlayerEliminatedRemote = Remotes:WaitForChild("PlayerEliminated")
 local State = game.ReplicatedStorage:WaitForChild("State")
 local RoundConfig = require(game.ReplicatedStorage.Modules.RoundConfig)
+local ThemeConfig = require(game.ReplicatedStorage.Modules.ThemeConfig)
 
 local gui = Instance.new("ScreenGui"); gui.Name = "MazeUI"; gui.ResetOnSpawn = false; gui.Parent = player:WaitForChild("PlayerGui")
 local function mkLabel(name, x, y)
@@ -830,6 +831,94 @@ local ToggleReady = Replicated.Remotes:WaitForChild("ToggleReady")
 local StartGameRequest = Replicated.Remotes:WaitForChild("StartGameRequest")
 local ThemeVote = Replicated.Remotes:WaitForChild("ThemeVote")
 
+local function getPreviewStands()
+        local lobbyFolder = workspace:FindFirstChild("Lobby")
+        if not lobbyFolder then
+                return {}
+        end
+        local result = {}
+        local function collectChildren(container)
+                if not container then
+                        return
+                end
+                for _, child in ipairs(container:GetChildren()) do
+                        if child:GetAttribute("ThemeId") then
+                                table.insert(result, child)
+                        end
+                end
+        end
+        collectChildren(lobbyFolder:FindFirstChild("PreviewStands"))
+        collectChildren(lobbyFolder)
+        return result
+end
+
+local function ensureHighlight(instance)
+        local highlight = instance:FindFirstChild("LobbyPreviewHighlight")
+        if not highlight then
+                highlight = Instance.new("Highlight")
+                highlight.Name = "LobbyPreviewHighlight"
+                highlight.Adornee = instance:IsA("Model") and instance or instance:FindFirstChildWhichIsA("BasePart", true)
+                highlight.FillTransparency = 0.8
+                highlight.OutlineTransparency = 1
+                highlight.DepthMode = Enum.HighlightDepthMode.Occluded
+                highlight.Parent = instance
+        end
+        if not highlight.Adornee or not highlight.Adornee.Parent then
+                if instance:IsA("Model") then
+                        highlight.Adornee = instance
+                else
+                        highlight.Adornee = instance:FindFirstChildWhichIsA("BasePart", true)
+                end
+        end
+        return highlight
+end
+
+local function setPreviewParticlesEnabled(container, enabled, color)
+        for _, descendant in ipairs(container:GetDescendants()) do
+                if descendant:IsA("ParticleEmitter") and descendant.Name == "LobbyPreviewParticles" then
+                        descendant.Enabled = enabled
+                        if color then
+                                descendant.Color = ColorSequence.new(color)
+                        end
+                elseif descendant:IsA("PointLight") and descendant.Name == "LobbyAccentLight" then
+                        descendant.Enabled = enabled
+                        if color then
+                                descendant.Color = color
+                        end
+                end
+        end
+end
+
+local function updatePreviewHighlights(targetThemeId, accentColor)
+        local stands = getPreviewStands()
+        if #stands == 0 then
+                return
+        end
+        for _, stand in ipairs(stands) do
+                local standThemeId = stand:GetAttribute("ThemeId")
+                local highlight = ensureHighlight(stand)
+                local isLeader = targetThemeId ~= nil and standThemeId == targetThemeId
+                highlight.Enabled = isLeader
+                if accentColor then
+                        highlight.FillColor = accentColor
+                        highlight.OutlineColor = accentColor
+                else
+                        local theme = standThemeId and ThemeConfig.Get(standThemeId)
+                        local fallback = theme and theme.primaryColor or Color3.fromRGB(255, 255, 255)
+                        highlight.FillColor = fallback
+                        highlight.OutlineColor = fallback
+                end
+                highlight.FillTransparency = isLeader and 0.6 or 1
+                highlight.OutlineTransparency = isLeader and 0 or 1
+                local particleColor = accentColor
+                if not particleColor then
+                        local theme = standThemeId and ThemeConfig.Get(standThemeId)
+                        particleColor = theme and theme.primaryColor or highlight.FillColor
+                end
+                setPreviewParticlesEnabled(stand, isLeader, isLeader and particleColor or nil)
+        end
+end
+
 local lobby = Instance.new("Frame"); lobby.Name = "Lobby"; lobby.Size = UDim2.new(0, 380, 0, 320)
 lobby.Position = UDim2.new(0.5, -190, 0, 10); lobby.BackgroundTransparency = 0.2; lobby.Parent = gui
 local title = Instance.new("TextLabel"); title.Size = UDim2.new(1,0,0,24); title.Text = "Lobby"; title.BackgroundTransparency = 1; title.Parent = lobby
@@ -974,17 +1063,19 @@ local function renderThemeState(themeState)
         if not themeState or not themeState.options then
                 themePanel.Visible = false
                 activeThemeVote = false
+                themeCountdown.Text = "Geen stemming"
+                themeCountdown.TextColor3 = Color3.fromRGB(220, 220, 220)
+                winningLabel.Text = "Volgende ronde: ?"
+                winningLabel.TextColor3 = Color3.fromRGB(220, 220, 220)
+                updatePreviewHighlights(nil, nil)
+                for _, entry in pairs(themeButtons) do
+                        entry.button.Visible = false
+                end
                 return
         end
 
-        if not lobby.Visible then
-                themePanel.Visible = false
-                activeThemeVote = themeState.active == true
-                return
-        end
-
-	themePanel.Visible = true
-	activeThemeVote = themeState.active == true
+        activeThemeVote = themeState.active == true
+        themePanel.Visible = lobby.Visible
 
 	local totalVotes = themeState.totalVotes or 0
 	local votesByPlayer = themeState.votesByPlayer or {}
@@ -1025,12 +1116,13 @@ local function renderThemeState(themeState)
 	local highlightId = activeThemeVote and leaderId or (themeState.current or leaderId)
 
 	local seen = {}
-	for index, option in ipairs(themeState.options) do
-		local entry = ensureThemeButton(option.id)
-		entry.button.LayoutOrder = index
+        for index, option in ipairs(themeState.options) do
+                local entry = ensureThemeButton(option.id)
+                entry.button.LayoutOrder = index
+                entry.button.Visible = true
 
-		local votes = votesLookup[option.id] or 0
-		local color = optionColors[option.id] or Color3.fromRGB(160,160,160)
+                local votes = votesLookup[option.id] or 0
+                local color = optionColors[option.id] or Color3.fromRGB(160,160,160)
 		local ratio = (totalVotes > 0) and math.clamp(votes / totalVotes, 0, 1) or 0
 
 		entry.fill.BackgroundColor3 = color
@@ -1053,22 +1145,28 @@ local function renderThemeState(themeState)
 		seen[option.id] = true
 	end
 
-	local labelId = highlightId
-	if activeThemeVote then
-		labelId = leaderId or labelId
-	else
-		labelId = themeState.current or labelId
-	end
-	if not labelId and #themeState.options > 0 then
-		labelId = themeState.options[1].id
-	end
+        local labelId = highlightId
+        if activeThemeVote then
+                labelId = leaderId or labelId
+        else
+                labelId = themeState.current or labelId
+        end
+        if not labelId and #themeState.options > 0 then
+                labelId = themeState.options[1].id
+        end
         local labelName = optionNames[labelId] or labelId or "?"
         if not activeThemeVote and themeState.currentName then
                 labelName = themeState.currentName
         end
 
+        local labelTheme = ThemeConfig.Get(labelId)
+        local highlightTheme = ThemeConfig.Get(highlightId)
+        local labelColor = optionColors[labelId] or (labelTheme and labelTheme.primaryColor) or Color3.fromRGB(220,220,220)
+        local accentColor = optionColors[highlightId] or (highlightTheme and highlightTheme.primaryColor) or labelColor
+
         winningLabel.Text = activeThemeVote and string.format("Voorlopige leider: %s", labelName) or string.format("Volgende ronde: %s", labelName)
-	winningLabel.TextColor3 = optionColors[labelId] or Color3.fromRGB(220,220,220)
+        winningLabel.TextColor3 = labelColor
+        updatePreviewHighlights(highlightId, accentColor)
 
 	for themeId, entry in pairs(themeButtons) do
 		if not seen[themeId] then


### PR DESCRIPTION
## Summary
- add lobby asset metadata for each lobby theme so servers can locate preview assets
- create a LobbyPreviewService to clone themed preview models, play ambient audio, and adjust lobby lighting
- update the client lobby UI to highlight the leading theme's preview stand with color and particle VFX

## Testing
- not run (Roblox environment)


------
https://chatgpt.com/codex/tasks/task_e_68e283ab745c8322b7960a292d2d065c