### PR TITLE
Add maze finder pickups and backpack tools

### DIFF
--- a/src/ServerScriptService/GameManager.server.lua
+++ b/src/ServerScriptService/GameManager.server.lua
@@ -131,17 +131,47 @@ end
 ensurePart("Wall", Vector3.new(Config.CellSize, Config.WallHeight, 1))
 ensurePart("Floor", Vector3.new(Config.CellSize, 1, Config.CellSize))
 if not prefabs:FindFirstChild("Key") then
-	local keyModel = Instance.new("Model"); keyModel.Name = "Key"; keyModel.Parent = prefabs
-	local part = Instance.new("Part"); part.Name = "Handle"; part.Size = Vector3.new(1,1,1); part.Anchored = true; part.Parent = keyModel
-	local pp = Instance.new("ProximityPrompt"); pp.Parent = part
-	keyModel.PrimaryPart = part
+        local keyModel = Instance.new("Model"); keyModel.Name = "Key"; keyModel.Parent = prefabs
+        local part = Instance.new("Part"); part.Name = "Handle"; part.Size = Vector3.new(1,1,1); part.Anchored = true; part.Parent = keyModel
+        local pp = Instance.new("ProximityPrompt"); pp.Parent = part
+        keyModel.PrimaryPart = part
 end
 if not prefabs:FindFirstChild("Door") then
         local door = Instance.new("Model"); door.Name = "Door"; door.Parent = prefabs
-	local part = Instance.new("Part"); part.Name = "Panel"; part.Size = Vector3.new(6,8,1); part.Anchored = true; part.Parent = door
-	local locked = Instance.new("BoolValue"); locked.Name = "Locked"; locked.Value = true; locked.Parent = door
-	door.PrimaryPart = part
+        local part = Instance.new("Part"); part.Name = "Panel"; part.Size = Vector3.new(6,8,1); part.Anchored = true; part.Parent = door
+        local locked = Instance.new("BoolValue"); locked.Name = "Locked"; locked.Value = true; locked.Parent = door
+        door.PrimaryPart = part
 end
+
+local function ensureFinderPrefab(name, color)
+        if prefabs:FindFirstChild(name) then
+                return
+        end
+
+        local model = Instance.new("Model")
+        model.Name = name
+        model.Parent = prefabs
+
+        local part = Instance.new("Part")
+        part.Name = "Handle"
+        part.Anchored = true
+        part.Size = Vector3.new(1.6, 1.6, 1.6)
+        part.Shape = Enum.PartType.Ball
+        part.Material = Enum.Material.Neon
+        part.Color = color
+        part.CanCollide = false
+        part.Parent = model
+
+        local prompt = Instance.new("ProximityPrompt")
+        prompt.Parent = part
+
+        model.PrimaryPart = part
+end
+
+ensureFinderPrefab("ExitFinder", Color3.fromRGB(0, 170, 255))
+ensureFinderPrefab("HunterFinder", Color3.fromRGB(255, 85, 85))
+ensureFinderPrefab("KeyFinder", Color3.fromRGB(255, 221, 79))
+
 ExitDoorBuilder.EnsureDoorPrefab(prefabs, Config)
 
 local function resizePartToWallHeight(part, height)

--- a/src/ServerScriptService/InventoryService.server.lua
+++ b/src/ServerScriptService/InventoryService.server.lua
@@ -4,13 +4,66 @@ local Players = game:GetService("Players")
 local Remotes = Replicated:WaitForChild("Remotes")
 local InventoryUpdate = Remotes:WaitForChild("InventoryUpdate")
 
-local Inventory = {}  -- [player.UserId] = { keys = int }
+local Inventory = {}  -- [player.UserId] = { keys = int, exitFinder = bool, hunterFinder = bool, keyFinder = bool }
 
-local KEY_TOOL_ATTRIBUTE = "MazeRushKeyTool"
-local KEY_TOOL_NAME = "Maze Key"
-local KEY_TOOL_TOOLTIP = "Gebruik deze sleutel om deuren in Maze Rush te openen."
+local TOOL_DEFINITIONS = {
+        {
+                attribute = "MazeRushKeyTool",
+                name = "Maze Key",
+                tooltip = "Gebruik deze sleutel om deuren in Maze Rush te openen.",
+                requiresHandle = false,
+                canBeDropped = false,
+                getDesiredCount = function(inv)
+                        return math.max(0, inv.keys or 0)
+                end,
+        },
+        {
+                attribute = "MazeRushExitFinderTool",
+                name = "Exit Finder",
+                tooltip = "Gebruik om het pad naar de uitgang te tonen.",
+                requiresHandle = false,
+                canBeDropped = false,
+                getDesiredCount = function(inv)
+                        return inv.exitFinder and 1 or 0
+                end,
+        },
+        {
+                attribute = "MazeRushHunterFinderTool",
+                name = "Hunter Finder",
+                tooltip = "Gebruik om jagers op te sporen.",
+                requiresHandle = false,
+                canBeDropped = false,
+                getDesiredCount = function(inv)
+                        return inv.hunterFinder and 1 or 0
+                end,
+        },
+        {
+                attribute = "MazeRushKeyFinderTool",
+                name = "Key Finder",
+                tooltip = "Gebruik om de dichtstbijzijnde sleutel te vinden.",
+                requiresHandle = false,
+                canBeDropped = false,
+                getDesiredCount = function(inv)
+                        return inv.keyFinder and 1 or 0
+                end,
+        },
+}
 
-local function gatherKeyTools(plr)
+local syncTools
+
+local function ensure(plr)
+        if not Inventory[plr.UserId] then
+                Inventory[plr.UserId] = {
+                        keys = 0,
+                        exitFinder = false,
+                        hunterFinder = false,
+                        keyFinder = false,
+                }
+        end
+        return Inventory[plr.UserId]
+end
+
+local function gatherTools(plr, attributeName)
         local containers = {}
         local backpack = plr:FindFirstChildOfClass("Backpack")
         if backpack then
@@ -22,30 +75,29 @@ local function gatherKeyTools(plr)
                 table.insert(containers, character)
         end
 
-        local keyTools = {}
+        local tools = {}
         for _, container in ipairs(containers) do
                 for _, child in ipairs(container:GetChildren()) do
-                        if child:IsA("Tool") and child:GetAttribute(KEY_TOOL_ATTRIBUTE) then
-                                table.insert(keyTools, child)
+                        if child:IsA("Tool") and child:GetAttribute(attributeName) then
+                                table.insert(tools, child)
                         end
                 end
         end
 
-        return keyTools, backpack
+        return tools, backpack
 end
 
-local function syncKeyTools(plr)
+local function syncToolDefinition(plr, inv, definition)
         if not plr or not plr.Parent then
                 return
         end
 
-        local inv = Inventory[plr.UserId]
         if not inv then
                 return
         end
 
-        local desired = math.max(0, inv.keys or 0)
-        local existingTools, backpack = gatherKeyTools(plr)
+        local desired = math.max(0, definition.getDesiredCount(inv))
+        local existingTools, backpack = gatherTools(plr, definition.attribute)
         local total = #existingTools
 
         if total > desired then
@@ -59,34 +111,44 @@ local function syncKeyTools(plr)
                 backpack = backpack or plr:FindFirstChildOfClass("Backpack")
                 if not backpack then
                         task.defer(function()
-                                syncKeyTools(plr)
+                                syncTools(plr)
                         end)
                         return
                 end
 
                 for _ = total + 1, desired do
                         local tool = Instance.new("Tool")
-                        tool.Name = KEY_TOOL_NAME
-                        tool.RequiresHandle = false
-                        tool.CanBeDropped = false
-                        tool:SetAttribute(KEY_TOOL_ATTRIBUTE, true)
-                        tool.ToolTip = KEY_TOOL_TOOLTIP
+                        tool.Name = definition.name
+                        tool.RequiresHandle = definition.requiresHandle == true
+                        tool.CanBeDropped = definition.canBeDropped == true
+                        tool:SetAttribute(definition.attribute, true)
+                        if definition.tooltip then
+                                tool.ToolTip = definition.tooltip
+                        end
+                        if definition.onCreate then
+                                pcall(definition.onCreate, tool)
+                        end
                         tool.Parent = backpack
                 end
         end
 end
 
-local function ensure(plr)
-        if not Inventory[plr.UserId] then
-                Inventory[plr.UserId] = { keys = 0 }
+syncTools = function(plr)
+        local inv = ensure(plr)
+        for _, definition in ipairs(TOOL_DEFINITIONS) do
+                syncToolDefinition(plr, inv, definition)
         end
-        return Inventory[plr.UserId]
 end
 
 local function pushClient(plr)
         local inv = ensure(plr)
-        InventoryUpdate:FireClient(plr, { keys = inv.keys })
-        syncKeyTools(plr)
+        InventoryUpdate:FireClient(plr, {
+                keys = inv.keys,
+                exitFinder = inv.exitFinder,
+                hunterFinder = inv.hunterFinder,
+                keyFinder = inv.keyFinder,
+        })
+        syncTools(plr)
 end
 
 local Service = {}
@@ -115,6 +177,42 @@ function Service.UseKey(plr, amount)
         return false
 end
 
+function Service.HasExitFinder(plr)
+        local inv = ensure(plr)
+        return inv.exitFinder == true
+end
+
+function Service.GrantExitFinder(plr)
+        local inv = ensure(plr)
+        inv.exitFinder = true
+        pushClient(plr)
+        return true
+end
+
+function Service.HasHunterFinder(plr)
+        local inv = ensure(plr)
+        return inv.hunterFinder == true
+end
+
+function Service.GrantHunterFinder(plr)
+        local inv = ensure(plr)
+        inv.hunterFinder = true
+        pushClient(plr)
+        return true
+end
+
+function Service.HasKeyFinder(plr)
+        local inv = ensure(plr)
+        return inv.keyFinder == true
+end
+
+function Service.GrantKeyFinder(plr)
+        local inv = ensure(plr)
+        inv.keyFinder = true
+        pushClient(plr)
+        return true
+end
+
 function Service.Reset(plr)
         if not plr then
                 return
@@ -122,12 +220,18 @@ function Service.Reset(plr)
 
         local inv = ensure(plr)
         inv.keys = 0
+        inv.exitFinder = false
+        inv.hunterFinder = false
+        inv.keyFinder = false
         pushClient(plr)
 end
 
 function Service.ResetAll()
         for userId, inv in pairs(Inventory) do
                 inv.keys = 0
+                inv.exitFinder = false
+                inv.hunterFinder = false
+                inv.keyFinder = false
                 local plr = Players:GetPlayerByUserId(userId)
                 if plr then
                         pushClient(plr)
@@ -143,7 +247,7 @@ Players.PlayerAdded:Connect(function(plr)
         pushClient(plr)
 
         local function trySync()
-                syncKeyTools(plr)
+                syncTools(plr)
         end
 
         plr.ChildAdded:Connect(function(child)


### PR DESCRIPTION
## Summary
- extend the inventory service to sync exit, hunter, and key finders into Roblox backpack tools
- spawn new exit, hunter, and key finder pickups in the maze and wire them to the inventory
- add client-side key finder controls and UI updates for all finder items, including path visualization

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e28707c70083228d6dced67758c0db