### PR TITLE
Fix ThemeConfig syntax error

### DIFF
--- a/src/ReplicatedStorage/Modules/ThemeConfig.lua
+++ b/src/ReplicatedStorage/Modules/ThemeConfig.lua
@@ -147,7 +147,6 @@ local ThemeList = {
                         },
                 },
         },
-    },
 }
 
 local ThemeMap = {}


### PR DESCRIPTION
## Summary
- remove an extra closing brace from `ThemeConfig.lua`
- restore the theme list table structure so the module parses correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2e74411088322972d89d6ec49a0ff