### PR TITLE
Fix exit door unlocking without a key

### DIFF
--- a/src/ServerScriptService/KeyDoorService.server.lua
+++ b/src/ServerScriptService/KeyDoorService.server.lua
@@ -237,7 +237,7 @@ local function safelyCall(inventory, methodName, ...)
         return false
     end
 
-    return result ~= nil and result or true
+    return result ~= nil and result or false
 end
 
 local function configureKeyPrompt(keyModel)
@@ -396,13 +396,13 @@ local function configureDoorPrompt(door, lockedValue)
         end
 
         local hasKey = safelyCall(inventory, "HasKey", plr)
-        if not hasKey then
+        if hasKey ~= true then
             prompt.Enabled = true
             return
         end
 
         local consumed = safelyCall(inventory, "UseKey", plr, 1)
-        if not consumed then
+        if consumed ~= true then
             prompt.Enabled = true
             return
         end


### PR DESCRIPTION
## Summary
- treat missing inventory results as failures so we never assume success when a method returns nil
- require the inventory service to explicitly return true before unlocking the exit door

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f4efaac883228f8a81bf8c4fe1f3