### PR TITLE
Fix lobby camera distance after rounds

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/FirstPersonCamera.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/FirstPersonCamera.client.lua
@@ -59,6 +59,26 @@ local originalMode = player.CameraMode
 local originalMinZoom = player.CameraMinZoomDistance
 local originalMaxZoom = player.CameraMaxZoomDistance
 
+local function restoreCameraMode()
+    if originalMode == Enum.CameraMode.LockFirstPerson then
+        player.CameraMode = Enum.CameraMode.Classic
+    else
+        player.CameraMode = originalMode
+    end
+end
+
+local function getLobbyZoomBounds()
+    local minZoom = math.min(originalMinZoom, LOBBY_DEFAULT_DISTANCE)
+    local maxZoom = math.max(originalMaxZoom, LOBBY_DEFAULT_DISTANCE)
+    return minZoom, maxZoom
+end
+
+local function applyLobbyZoomBounds()
+    local minZoom, maxZoom = getLobbyZoomBounds()
+    player.CameraMinZoomDistance = minZoom
+    player.CameraMaxZoomDistance = maxZoom
+end
+
 local firstPersonActive = false
 local currentPhase = "IDLE"
 
@@ -149,7 +169,7 @@ local function enableFirstPerson()
     setCameraSubject(player.Character)
 end
 
-local function snapCameraBehindCharacter()
+local function snapCameraBehindCharacter(forceDesiredDistance)
     local camera = workspace.CurrentCamera
     if not camera then
         return
@@ -161,8 +181,7 @@ local function snapCameraBehindCharacter()
         return
     end
 
-    local minZoom = math.min(originalMinZoom, LOBBY_DEFAULT_DISTANCE)
-    local maxZoom = math.max(originalMaxZoom, LOBBY_DEFAULT_DISTANCE)
+    local minZoom, maxZoom = getLobbyZoomBounds()
     local desiredDistance = math.clamp(LOBBY_DEFAULT_DISTANCE, minZoom, maxZoom)
 
     local heightOffset = math.clamp(desiredDistance * 0.4, 2, 8)
@@ -172,26 +191,48 @@ local function snapCameraBehindCharacter()
 
     camera.CameraType = Enum.CameraType.Custom
     camera.CameraSubject = humanoid
+    if forceDesiredDistance then
+        local previousMin = player.CameraMinZoomDistance
+        local previousMax = player.CameraMaxZoomDistance
+
+        player.CameraMinZoomDistance = desiredDistance
+        player.CameraMaxZoomDistance = math.max(previousMax, maxZoom)
+
+        camera.CFrame = CFrame.new(cameraPosition, lookAtPosition)
+        camera.Focus = CFrame.new(lookAtPosition)
+
+        task.defer(function()
+            if not firstPersonActive and not shouldLockFirstPerson() then
+                applyLobbyZoomBounds()
+            else
+                player.CameraMinZoomDistance = previousMin
+                player.CameraMaxZoomDistance = previousMax
+            end
+        end)
+
+        return
+    end
+
+    applyLobbyZoomBounds()
     camera.CFrame = CFrame.new(cameraPosition, lookAtPosition)
+    camera.Focus = CFrame.new(lookAtPosition)
 end
 
 local function disableFirstPerson()
     if not firstPersonActive then
-        player.CameraMode = originalMode
-        player.CameraMinZoomDistance = math.min(originalMinZoom, LOBBY_DEFAULT_DISTANCE)
-        player.CameraMaxZoomDistance = math.max(originalMaxZoom, LOBBY_DEFAULT_DISTANCE)
+        restoreCameraMode()
+        applyLobbyZoomBounds()
         if not shouldLockFirstPerson() then
-            snapCameraBehindCharacter()
+            snapCameraBehindCharacter(true)
         end
         return
     end
 
     firstPersonActive = false
-    player.CameraMode = originalMode
-    player.CameraMinZoomDistance = math.min(originalMinZoom, LOBBY_DEFAULT_DISTANCE)
-    player.CameraMaxZoomDistance = math.max(originalMaxZoom, LOBBY_DEFAULT_DISTANCE)
+    restoreCameraMode()
+    applyLobbyZoomBounds()
     if not shouldLockFirstPerson() then
-        snapCameraBehindCharacter()
+        snapCameraBehindCharacter(true)
     end
 end
 

--- a/src/StarterPlayer/StarterPlayerScripts/FirstPersonCamera.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/FirstPersonCamera.client.lua
@@ -53,6 +53,7 @@ end
 
 local MIN_ZOOM = 0.5
 local MAX_ZOOM = 0.5
+local LOBBY_DEFAULT_DISTANCE = 12
 
 local originalMode = player.CameraMode
 local originalMinZoom = player.CameraMinZoomDistance
@@ -160,12 +161,9 @@ local function snapCameraBehindCharacter()
         return
     end
 
-    local desiredDistance = (originalMinZoom + originalMaxZoom) * 0.5
-    if desiredDistance < originalMinZoom then
-        desiredDistance = originalMinZoom
-    elseif desiredDistance > originalMaxZoom then
-        desiredDistance = originalMaxZoom
-    end
+    local minZoom = math.min(originalMinZoom, LOBBY_DEFAULT_DISTANCE)
+    local maxZoom = math.max(originalMaxZoom, LOBBY_DEFAULT_DISTANCE)
+    local desiredDistance = math.clamp(LOBBY_DEFAULT_DISTANCE, minZoom, maxZoom)
 
     local heightOffset = math.clamp(desiredDistance * 0.4, 2, 8)
 
@@ -180,8 +178,8 @@ end
 local function disableFirstPerson()
     if not firstPersonActive then
         player.CameraMode = originalMode
-        player.CameraMinZoomDistance = originalMinZoom
-        player.CameraMaxZoomDistance = originalMaxZoom
+        player.CameraMinZoomDistance = math.min(originalMinZoom, LOBBY_DEFAULT_DISTANCE)
+        player.CameraMaxZoomDistance = math.max(originalMaxZoom, LOBBY_DEFAULT_DISTANCE)
         if not shouldLockFirstPerson() then
             snapCameraBehindCharacter()
         end
@@ -190,8 +188,8 @@ local function disableFirstPerson()
 
     firstPersonActive = false
     player.CameraMode = originalMode
-    player.CameraMinZoomDistance = originalMinZoom
-    player.CameraMaxZoomDistance = originalMaxZoom
+    player.CameraMinZoomDistance = math.min(originalMinZoom, LOBBY_DEFAULT_DISTANCE)
+    player.CameraMaxZoomDistance = math.max(originalMaxZoom, LOBBY_DEFAULT_DISTANCE)
     if not shouldLockFirstPerson() then
         snapCameraBehindCharacter()
     end


### PR DESCRIPTION
## Summary
- ensure the camera restores a comfortable third-person distance when leaving a maze round
- clamp the zoom distances so the lobby view snaps behind the character instead of remaining first-person

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e58003b7908322881e3e76cdad1c9c