### PR TITLE
Require line-of-sight to interact with maze pickups

### DIFF
--- a/src/ServerScriptService/KeyDoorService.server.lua
+++ b/src/ServerScriptService/KeyDoorService.server.lua
@@ -257,7 +257,7 @@ local function configureKeyPrompt(keyModel)
     prompt.ActionText = "Pick Up Key"
     prompt.ObjectText = "Key"
     prompt.HoldDuration = 0
-    prompt.RequiresLineOfSight = false
+    prompt.RequiresLineOfSight = true
     prompt.MaxActivationDistance = 12
 
     prompt.Triggered:Connect(function(plr)
@@ -308,7 +308,7 @@ local function configureFinderPrompt(model, options)
     prompt.ActionText = options.actionText or ("Pick Up " .. displayName)
     prompt.ObjectText = options.objectText or displayName
     prompt.HoldDuration = 0
-    prompt.RequiresLineOfSight = false
+    prompt.RequiresLineOfSight = true
     prompt.MaxActivationDistance = options.maxDistance or 12
 
     prompt.Triggered:Connect(function(plr)
@@ -375,7 +375,7 @@ local function configureDoorPrompt(door, lockedValue)
     prompt.Parent = panel
     prompt.ActionText = "Unlock Door"
     prompt.ObjectText = "Exit Door"
-    prompt.RequiresLineOfSight = false
+    prompt.RequiresLineOfSight = true
     prompt.MaxActivationDistance = 10
 
     prompt.Triggered:Connect(function(plr)


### PR DESCRIPTION
## Summary
- enable line-of-sight checks for maze key, finder, and door prompts to prevent interaction through walls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e582b7e7708322b8cc35f855fb873b