### PR TITLE
Adjust lobby theme votes label positioning

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/LobbyBoard.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/LobbyBoard.client.lua
@@ -983,13 +983,14 @@ local function ensureThemeOptionEntry(themeId)
 
     local votesLabel = Instance.new("TextLabel")
     votesLabel.Name = "Votes"
+    votesLabel.AnchorPoint = Vector2.new(1, 1)
     votesLabel.BackgroundTransparency = 1
     votesLabel.Font = Enum.Font.GothamSemibold
     votesLabel.TextSize = 20
     votesLabel.TextColor3 = Color3.fromRGB(210, 220, 240)
     votesLabel.TextXAlignment = Enum.TextXAlignment.Right
-    votesLabel.Position = UDim2.new(0.5, 2, 0, 50)
-    votesLabel.Size = UDim2.new(0.5, -16, 0, 32)
+    votesLabel.Position = UDim2.new(1, -16, 1, -12)
+    votesLabel.Size = UDim2.new(0.48, 0, 0, 26)
     votesLabel.Parent = button
 
     button.MouseButton1Click:Connect(function()


### PR DESCRIPTION
## Summary
- reposition the theme option votes label within the lobby board button so it stays inside the 72px layout
- anchor the votes label to the button's bottom-right corner to prevent clipping when descendants are clipped

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5984738fc83228c75d8d44302ac6a