### PR TITLE
Allow lobby board height overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 ## Lobby-bord hoger plaatsen
 
 1. Open de lobby in Studio en selecteer het onderdeel dat het bord moet dragen (meestal het onderdeel met het `LobbyBoardAnchor`-attribuut). Je kunt de `Lobby`-folder zelf selecteren als je de waarde globaal wilt toepassen.
-2. Voeg in het **Attributes**-paneel een `Number`-attribuut `LobbyBoardHeightCoverage` toe. Kies een waarde tussen `0` en `1` die aangeeft welk percentage van de opgegeven muurhoogte het bord mag vullen (bijvoorbeeld `0.9` om dichter tegen het plafond aan te komen).
-3. Voeg optioneel een `Number`-attribuut `LobbyBoardBottomPadding` toe om de onderkant van het bord een extra marge te geven boven de vloer (bijvoorbeeld `0.05` voor 5% van de muurhoogte).
+2. Voeg in het **Attributes**-paneel een `Number`-attribuut `LobbyBoardHeightCoverage` toe. Kies een waarde tussen `0` en `1` die aangeeft welk percentage van de opgegeven muurhoogte het bord mag vullen (bijvoorbeeld `0.9` om dichter tegen het plafond aan te komen). Het script zorgt ervoor dat deze waarde nooit hoger is dan `1 - LobbyBoardBottomPadding`, zodat het bord binnen de muurhoogte past.
+3. Voeg optioneel een `Number`-attribuut `LobbyBoardBottomPadding` toe om de onderkant van het bord een extra marge te geven boven de vloer (bijvoorbeeld `0.05` voor 5% van de muurhoogte). Een hogere padding betekent automatisch dat de maximale hoogte-coverage iets krimpt, zodat de topzijde niet door het plafond steekt.
 4. Druk op **Play** of **F5**: het script leest deze overrides en centreert de `PlayerStand`/`ThemeStand` opnieuw zodat het bord symmetrisch binnen de opgegeven hoogte blijft.
 
 ## Inventory en Roblox-backpack

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 ## Lobby-bord hoger plaatsen
 
 1. Open de lobby in Studio en selecteer het onderdeel dat het bord moet dragen (meestal het onderdeel met het `LobbyBoardAnchor`-attribuut). Je kunt de `Lobby`-folder zelf selecteren als je de waarde globaal wilt toepassen.
-2. Voeg in het **Attributes**-paneel een `Number`-attribuut `LobbyBoardHeightCoverage` toe. Kies een waarde tussen `0` en `1` die aangeeft welk percentage van de opgegeven muurhoogte het bord mag vullen (bijvoorbeeld `0.9` om dichter tegen het plafond aan te komen). Het script zorgt ervoor dat deze waarde nooit hoger is dan `1 - LobbyBoardBottomPadding`, zodat het bord binnen de muurhoogte past.
-3. Voeg optioneel een `Number`-attribuut `LobbyBoardBottomPadding` toe om de onderkant van het bord een extra marge te geven boven de vloer (bijvoorbeeld `0.05` voor 5% van de muurhoogte). Een hogere padding betekent automatisch dat de maximale hoogte-coverage iets krimpt, zodat de topzijde niet door het plafond steekt.
+2. Voeg in het **Attributes**-paneel een `Number`-attribuut `LobbyBoardHeightCoverage` toe. Kies een waarde tussen `0` en `1` die aangeeft welk percentage van de opgegeven muurhoogte het bord mag vullen (bijvoorbeeld `0.9` om dichter tegen het plafond aan te komen). Je kunt ook `90` (percentage) of `9` (studs) invullen: de scriptlogica rekent de override automatisch om naar een fractie. Het script zorgt ervoor dat deze waarde nooit hoger is dan `1 - LobbyBoardBottomPadding`, zodat het bord binnen de muurhoogte past.
+3. Voeg optioneel een `Number`-attribuut `LobbyBoardBottomPadding` toe om de onderkant van het bord een extra marge te geven boven de vloer (bijvoorbeeld `0.05` voor 5% van de muurhoogte, of `2` voor 2 studs). Een hogere padding betekent automatisch dat de maximale hoogte-coverage iets krimpt, zodat de topzijde niet door het plafond steekt.
 4. Druk op **Play** of **F5**: het script leest deze overrides en centreert de `PlayerStand`/`ThemeStand` opnieuw zodat het bord symmetrisch binnen de opgegeven hoogte blijft.
 
 ## Inventory en Roblox-backpack

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - **LoopChance**: stel in welk percentage muren na generatie verwijderd wordt (maakt lussen, standaard 5%).
 - **Lobby UI** met knoppen (DFS/PRIM + loop-kans). Client vraagt wissels aan; server valideert en zet de waardes.
 - **MazeGenerator** leest runtime-waardes; valt terug op `RoundConfig` bij ontbreken.
+- **Lobby-statusbord overrides** via attributes `LobbyBoardHeightCoverage` en `LobbyBoardBottomPadding` om het bord binnen de muurhoogte te verschuiven.
 
 ## Snel starten
 1. `rojo serve` of `rojo build --output MazeRush.rbxlx`
@@ -17,6 +18,13 @@
 - `src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua` – UI voor toggles, loop-kans en basis HUD.
 
 > Tip: Je kunt ook server-only wisselen door `State.MazeAlgorithm.Value = "PRIM"` in de command bar te zetten.
+
+## Lobby-bord hoger plaatsen
+
+1. Open de lobby in Studio en selecteer het onderdeel dat het bord moet dragen (meestal het onderdeel met het `LobbyBoardAnchor`-attribuut). Je kunt de `Lobby`-folder zelf selecteren als je de waarde globaal wilt toepassen.
+2. Voeg in het **Attributes**-paneel een `Number`-attribuut `LobbyBoardHeightCoverage` toe. Kies een waarde tussen `0` en `1` die aangeeft welk percentage van de opgegeven muurhoogte het bord mag vullen (bijvoorbeeld `0.9` om dichter tegen het plafond aan te komen).
+3. Voeg optioneel een `Number`-attribuut `LobbyBoardBottomPadding` toe om de onderkant van het bord een extra marge te geven boven de vloer (bijvoorbeeld `0.05` voor 5% van de muurhoogte).
+4. Druk op **Play** of **F5**: het script leest deze overrides en centreert de `PlayerStand`/`ThemeStand` opnieuw zodat het bord symmetrisch binnen de opgegeven hoogte blijft.
 
 ## Inventory en Roblox-backpack
 Maze Rush houdt de inventaris server-side bij in `InventoryService` en deelt die service via `_G.Inventory` zodat bijvoorbeeld `KeyDoorService` kan valideren of iemand een sleutel bezit. Vanaf nu spiegelt de service ook automatisch het sleutel-aantal naar de standaard Roblox-backpack: voor elke sleutel verschijnt er een `Maze Key`-tool (zonder handle) in de backpack van de speler.

--- a/src/ServerScriptService/EnsureLobbyBoard.server.lua
+++ b/src/ServerScriptService/EnsureLobbyBoard.server.lua
@@ -209,18 +209,21 @@ local function normalizeBoardFraction(value, wallHeight, baseline)
 
     local candidates = {}
     local function pushCandidate(candidateValue)
-        local withinRange = candidateValue >= 0 and candidateValue <= 1 and 0 or 1
+        local clampedValue = math.clamp(candidateValue, 0, 1)
+        local clampOffset = math.abs(candidateValue - clampedValue)
+        local withinRange = clampedValue >= 0 and clampedValue <= 1 and 0 or 1
         local deviation
         if typeof(baseline) == "number" then
-            deviation = math.abs(candidateValue - baseline)
+            deviation = math.abs(clampedValue - baseline)
         else
-            deviation = math.abs(candidateValue)
+            deviation = math.abs(clampedValue)
         end
         candidates[#candidates + 1] = {
-            value = candidateValue,
+            value = clampedValue,
             withinRange = withinRange,
             deviation = deviation,
-            magnitude = math.abs(candidateValue),
+            magnitude = math.abs(clampedValue),
+            clampOffset = clampOffset,
         }
     end
 
@@ -234,14 +237,17 @@ local function normalizeBoardFraction(value, wallHeight, baseline)
 
     if #candidates == 0 then
         if wallHeight and wallHeight > 0 then
-            return value / wallHeight
+            return math.clamp(value / wallHeight, 0, 1)
         end
-        return value / 100
+        return math.clamp(value / 100, 0, 1)
     end
 
     table.sort(candidates, function(a, b)
         if a.withinRange ~= b.withinRange then
             return a.withinRange < b.withinRange
+        end
+        if a.clampOffset ~= b.clampOffset then
+            return a.clampOffset < b.clampOffset
         end
         if a.deviation ~= b.deviation then
             return a.deviation < b.deviation

--- a/src/ServerScriptService/EnsureLobbyBoard.server.lua
+++ b/src/ServerScriptService/EnsureLobbyBoard.server.lua
@@ -206,8 +206,9 @@ local function resolveBoardLayoutOverrides(lobby, anchor)
         bottomPadding = lobbyBottomPadding
     end
 
-    heightCoverage = math.clamp(heightCoverage, 0, 1)
     bottomPadding = math.clamp(bottomPadding, 0, 1)
+    local maxCoverage = math.clamp(1 - bottomPadding, 0, 1)
+    heightCoverage = math.clamp(heightCoverage, 0, maxCoverage)
 
     return heightCoverage, bottomPadding
 end

--- a/src/ServerScriptService/EnsureLobbyBoard.server.lua
+++ b/src/ServerScriptService/EnsureLobbyBoard.server.lua
@@ -95,18 +95,58 @@ local function createTextLabel(parent, name, text, size, position, props)
     return label
 end
 
+local function configureSurfaceGui(surfaceGui)
+    if not surfaceGui or not surfaceGui:IsA("SurfaceGui") then
+        return
+    end
+
+    surfaceGui.SizingMode = Enum.SurfaceGuiSizingMode.PixelsPerStud
+    surfaceGui.PixelsPerStud = 75
+    surfaceGui.LightInfluence = 0
+    surfaceGui.ResetOnSpawn = false
+    surfaceGui.AlwaysOnTop = false
+    surfaceGui.Active = true
+end
+
+local function configureBoardRootFrame(frame)
+    if not frame or not frame:IsA("GuiObject") then
+        return
+    end
+
+    frame.AnchorPoint = Vector2.new(0, 0)
+    frame.Position = UDim2.fromScale(0, 0)
+    frame.Size = UDim2.fromScale(1, 1)
+
+    local aspect = frame:FindFirstChildOfClass("UIAspectRatioConstraint")
+    if aspect then
+        aspect:Destroy()
+    end
+
+    local padding = frame:FindFirstChildOfClass("UIPadding")
+    if not padding then
+        padding = Instance.new("UIPadding")
+        padding.Parent = frame
+    end
+
+    padding.PaddingTop = UDim.new(0.06, 0)
+    padding.PaddingBottom = UDim.new(0.06, 0)
+    padding.PaddingLeft = UDim.new(0.04, 0)
+    padding.PaddingRight = UDim.new(0.04, 0)
+end
+
 local function createSurface(stand, name)
     local gui = Instance.new("SurfaceGui")
     gui.Name = name
     gui.Face = Enum.NormalId.Front
     gui.LightInfluence = 0
     gui.SizingMode = Enum.SurfaceGuiSizingMode.PixelsPerStud
-    gui.PixelsPerStud = 60
+    gui.PixelsPerStud = 75
     gui.ResetOnSpawn = false
     gui.AlwaysOnTop = false
     gui.Active = true
     gui.Adornee = stand
     gui.Parent = stand
+    configureSurfaceGui(gui)
     return gui
 end
 
@@ -441,9 +481,32 @@ local function ensureLobbyBoard()
         local startPanelExisting = existing:FindFirstChild("StartPanel")
         local startButtonExisting = existing:FindFirstChild("StartButton")
 
+        local playerSurfaceExisting = playerStandExisting and playerStandExisting:FindFirstChild("PlayerSurface")
+        if playerSurfaceExisting then
+            configureSurfaceGui(playerSurfaceExisting)
+        end
+
+        local playerBoardExisting = playerSurfaceExisting and playerSurfaceExisting:FindFirstChild("PlayerBoard")
+        if playerBoardExisting then
+            configureBoardRootFrame(playerBoardExisting)
+
+            local playerListExisting = playerBoardExisting:FindFirstChild("PlayerList")
+            if playerListExisting and playerListExisting:IsA("GuiObject") then
+                local listLayout = playerListExisting:FindFirstChildOfClass("UIListLayout")
+                if listLayout then
+                    listLayout.Padding = UDim.new(0.01, 0)
+                end
+            end
+        end
+
         local themeSurfaceExisting = themeStandExisting and themeStandExisting:FindFirstChild("ThemeSurface")
+        if themeSurfaceExisting then
+            configureSurfaceGui(themeSurfaceExisting)
+        end
         local themePanelExisting = themeSurfaceExisting and themeSurfaceExisting:FindFirstChild("ThemePanel")
         if themePanelExisting then
+            configureBoardRootFrame(themePanelExisting)
+
             local themeHeaderExisting = themePanelExisting:FindFirstChild("ThemeHeader")
             if themeHeaderExisting and themeHeaderExisting:IsA("TextLabel") then
                 themeHeaderExisting.Size = UDim2.new(0.6, -40, 0, 44)
@@ -480,7 +543,7 @@ local function ensureLobbyBoard()
                 themeOptionsExisting.Position = UDim2.new(0, 22, 0, 178)
                 local layout = themeOptionsExisting:FindFirstChildOfClass("UIListLayout")
                 if layout then
-                    layout.Padding = UDim.new(0, 18)
+                    layout.Padding = UDim.new(0.012, 0)
                 end
             end
 
@@ -554,6 +617,7 @@ local function ensureLobbyBoard()
         BackgroundColor3 = Color3.fromRGB(34, 38, 54),
         ClipsDescendants = false,
     })
+    configureBoardRootFrame(playerBoard)
 
     local boardCorner = Instance.new("UICorner")
     boardCorner.CornerRadius = UDim.new(0, 24)
@@ -594,7 +658,7 @@ local function ensureLobbyBoard()
     local listLayout = Instance.new("UIListLayout")
     listLayout.FillDirection = Enum.FillDirection.Vertical
     listLayout.SortOrder = Enum.SortOrder.LayoutOrder
-    listLayout.Padding = UDim.new(0, 16)
+    listLayout.Padding = UDim.new(0.01, 0)
     listLayout.Parent = playerList
 
     local themeSurface = createSurface(themeStand, "ThemeSurface")
@@ -603,6 +667,7 @@ local function ensureLobbyBoard()
         BackgroundColor3 = Color3.fromRGB(30, 36, 56),
         ClipsDescendants = false,
     })
+    configureBoardRootFrame(themePanel)
 
     local themeCorner = Instance.new("UICorner")
     themeCorner.CornerRadius = UDim.new(0, 24)
@@ -659,7 +724,7 @@ local function ensureLobbyBoard()
     local themeOptionsLayout = Instance.new("UIListLayout")
     themeOptionsLayout.FillDirection = Enum.FillDirection.Vertical
     themeOptionsLayout.SortOrder = Enum.SortOrder.LayoutOrder
-    themeOptionsLayout.Padding = UDim.new(0, 18)
+    themeOptionsLayout.Padding = UDim.new(0.012, 0)
     themeOptionsLayout.Parent = themeOptions
 
     createTextLabel(themePanel, "ThemeHint", "Open de console met [E] om te stemmen of kies willekeurig.", UDim2.new(1, -44, 0, 72), UDim2.new(0, 22, 1, -76), {


### PR DESCRIPTION
## Summary
- allow lobby board scripts to read optional height coverage and bottom padding overrides from the lobby or anchor
- recalculate board placement using the new overrides so the player and theme stands stay centered within the wall
- document how to configure the new attributes in Studio

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e59a3ff7dc8322b3cc0085c7b701c5