### PR TITLE
Prevent monsters from entering exit room

### DIFF
--- a/src/ServerScriptService/CollisionGroupService.server.lua
+++ b/src/ServerScriptService/CollisionGroupService.server.lua
@@ -13,7 +13,7 @@ local function setPartGroup(part, groupName)
         return
     end
     local ok, err = pcall(function()
-        PhysicsService:SetPartCollisionGroup(part, groupName)
+        part.CollisionGroup = groupName
     end)
     if not ok then
         warn(string.format("[CollisionGroupService] Failed to set collision group '%s' for %s: %s", tostring(groupName), part:GetFullName(), tostring(err)))

--- a/src/ServerScriptService/CollisionGroupService.server.lua
+++ b/src/ServerScriptService/CollisionGroupService.server.lua
@@ -1,0 +1,63 @@
+local Players = game:GetService("Players")
+local CollectionService = game:GetService("CollectionService")
+local PhysicsService = game:GetService("PhysicsService")
+local ServerScriptService = game:GetService("ServerScriptService")
+
+local CollisionGroups = require(ServerScriptService:WaitForChild("CollisionGroups"))
+CollisionGroups.Ensure()
+
+local GROUPS = CollisionGroups.Groups
+
+local function setPartGroup(part, groupName)
+    if not (part and part:IsA("BasePart")) then
+        return
+    end
+    local ok, err = pcall(function()
+        PhysicsService:SetPartCollisionGroup(part, groupName)
+    end)
+    if not ok then
+        warn(string.format("[CollisionGroupService] Failed to set collision group '%s' for %s: %s", tostring(groupName), part:GetFullName(), tostring(err)))
+    end
+end
+
+local function applyGroupToModel(model, groupName)
+    if not model then
+        return
+    end
+    for _, descendant in ipairs(model:GetDescendants()) do
+        if descendant:IsA("BasePart") then
+            setPartGroup(descendant, groupName)
+        end
+    end
+    model.DescendantAdded:Connect(function(descendant)
+        if descendant:IsA("BasePart") then
+            setPartGroup(descendant, groupName)
+        end
+    end)
+end
+
+local function onCharacterAdded(character)
+    applyGroupToModel(character, GROUPS.Player)
+end
+
+local function onPlayerAdded(player)
+    player.CharacterAdded:Connect(onCharacterAdded)
+    local character = player.Character
+    if character then
+        onCharacterAdded(character)
+    end
+end
+
+Players.PlayerAdded:Connect(onPlayerAdded)
+for _, player in ipairs(Players:GetPlayers()) do
+    onPlayerAdded(player)
+end
+
+local function onEnemyAdded(enemy)
+    applyGroupToModel(enemy, GROUPS.Enemy)
+end
+
+CollectionService:GetInstanceAddedSignal("Enemy"):Connect(onEnemyAdded)
+for _, enemy in ipairs(CollectionService:GetTagged("Enemy")) do
+    onEnemyAdded(enemy)
+end

--- a/src/ServerScriptService/CollisionGroups.lua
+++ b/src/ServerScriptService/CollisionGroups.lua
@@ -11,12 +11,12 @@ CollisionGroups.Groups = {
 local ensured = false
 
 local function ensureGroup(name)
-    for _, group in ipairs(PhysicsService:GetCollisionGroups()) do
+    for _, group in ipairs(PhysicsService:GetRegisteredCollisionGroups()) do
         if group.name == name then
             return
         end
     end
-    PhysicsService:CreateCollisionGroup(name)
+    PhysicsService:RegisterCollisionGroup(name)
 end
 
 function CollisionGroups.Ensure()

--- a/src/ServerScriptService/CollisionGroups.lua
+++ b/src/ServerScriptService/CollisionGroups.lua
@@ -1,0 +1,42 @@
+local PhysicsService = game:GetService("PhysicsService")
+
+local CollisionGroups = {}
+
+CollisionGroups.Groups = {
+    Player = "MazeRushPlayers",
+    Enemy = "MazeRushEnemies",
+    ExitBarrier = "MazeRushExitBarrier",
+}
+
+local ensured = false
+
+local function ensureGroup(name)
+    for _, group in ipairs(PhysicsService:GetCollisionGroups()) do
+        if group.name == name then
+            return
+        end
+    end
+    PhysicsService:CreateCollisionGroup(name)
+end
+
+function CollisionGroups.Ensure()
+    if ensured then
+        return
+    end
+    ensured = true
+
+    for _, name in pairs(CollisionGroups.Groups) do
+        ensureGroup(name)
+    end
+
+    local groups = CollisionGroups.Groups
+
+    PhysicsService:CollisionGroupSetCollidable(groups.Player, groups.ExitBarrier, false)
+    PhysicsService:CollisionGroupSetCollidable(groups.Enemy, groups.ExitBarrier, true)
+    PhysicsService:CollisionGroupSetCollidable(groups.Enemy, groups.Player, true)
+    PhysicsService:CollisionGroupSetCollidable(groups.Player, groups.Player, true)
+    PhysicsService:CollisionGroupSetCollidable(groups.Enemy, groups.Enemy, true)
+    PhysicsService:CollisionGroupSetCollidable(groups.ExitBarrier, groups.ExitBarrier, true)
+end
+
+return CollisionGroups

--- a/src/ServerScriptService/KeyDoorService.server.lua
+++ b/src/ServerScriptService/KeyDoorService.server.lua
@@ -223,7 +223,7 @@ local function ensureExitPadBarrier()
     barrier.CanCollide = true
 
     local ok, err = pcall(function()
-        PhysicsService:SetPartCollisionGroup(barrier, COLLISION_GROUPS.ExitBarrier)
+        barrier.CollisionGroup = COLLISION_GROUPS.ExitBarrier
     end)
     if not ok then
         warn(string.format("KeyDoorService: Failed to assign collision group to exit pad barrier: %s", tostring(err)))
@@ -234,7 +234,7 @@ local function ensureExitPadBarrier()
         modifier = Instance.new("PathfindingModifier")
         modifier.Parent = barrier
     end
-    modifier.PassThroughCost = math.huge
+    modifier.PassThrough = false
 
     return barrier
 end


### PR DESCRIPTION
## Summary
- add shared collision-group configuration for players, enemies, and the exit barrier
- assign characters and enemy models to their collision groups when they spawn
- rebuild the exit pad barrier so monsters collide with it while players can pass through

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e682e3856c8322a70d8742008515c9