### PR TITLE
Add round rewards and progression unlocks

### DIFF
--- a/src/ReplicatedStorage/Modules/RoundConfig.lua
+++ b/src/ReplicatedStorage/Modules/RoundConfig.lua
@@ -128,16 +128,22 @@ local Config = {
 			MaxSeconds = 240,
 			Description = "Beloning per seconde dat de speler de actieve fase overleeft.",
 		},
-		Escape = {
-			Coins = 75,
-			XP = 150,
-			Description = "Bonus voor het bereiken van de uitgang voordat de tijd om is.",
-		},
-		Elimination = {
-			CoinsPerAction = 25,
-			XPPerAction = 45,
-			Description = "Beloning per vijand of val die door de speler wordt uitgeschakeld.",
-		},
+                Escape = {
+                        Coins = 75,
+                        XP = 150,
+                        Description = "Bonus voor het bereiken van de uitgang voordat de tijd om is.",
+                },
+                FullMazeExploration = {
+                        Coins = 30000,
+                        XP = 20000,
+                        Name = "Volledige verkenning",
+                        Description = "Volledige beloning voor spelers die elke tegel van de maze in één ronde bezoeken.",
+                },
+                Elimination = {
+                        CoinsPerAction = 25,
+                        XPPerAction = 45,
+                        Description = "Beloning per vijand of val die door de speler wordt uitgeschakeld.",
+                },
 		Unlocks = {
 			{
 				Id = "ExitFinder",

--- a/src/ReplicatedStorage/Modules/RoundConfig.lua
+++ b/src/ReplicatedStorage/Modules/RoundConfig.lua
@@ -114,6 +114,58 @@ local Config = {
                 },
         },
 
+	-- Beloningsconfiguratie: ontwerpers kunnen deze waarden aanpassen zonder scripts te wijzigen.
+	-- Coins/XP zijn gehele bedragen; per-seconde/-actie waarden worden afgerond op hele nummers.
+	Rewards = {
+		Participation = {
+			Coins = 15,
+			XP = 20,
+			Description = "Basistoelage voor spelers die bij de start van de ronde aanwezig waren.",
+		},
+		Survival = {
+			CoinsPerSecond = 0.4,
+			XPPerSecond = 0.9,
+			MaxSeconds = 240,
+			Description = "Beloning per seconde dat de speler de actieve fase overleeft.",
+		},
+		Escape = {
+			Coins = 75,
+			XP = 150,
+			Description = "Bonus voor het bereiken van de uitgang voordat de tijd om is.",
+		},
+		Elimination = {
+			CoinsPerAction = 25,
+			XPPerAction = 45,
+			Description = "Beloning per vijand of val die door de speler wordt uitgeschakeld.",
+		},
+		Unlocks = {
+			{
+				Id = "ExitFinder",
+				Name = "Exit Finder",
+				Reward = "ExitFinder",
+				Coins = 200,
+				XP = 150,
+				Description = "Ontgrendelt de Exit Finder gadget in de inventaris.",
+			},
+			{
+				Id = "HunterFinder",
+				Name = "Hunter Finder",
+				Reward = "HunterFinder",
+				Coins = 400,
+				XP = 350,
+				Description = "Ontgrendelt de Hunter Finder gadget in de inventaris.",
+			},
+			{
+				Id = "KeyFinder",
+				Name = "Key Finder",
+				Reward = "KeyFinder",
+				Coins = 650,
+				XP = 550,
+				Description = "Ontgrendelt de Key Finder gadget in de inventaris.",
+			},
+		},
+	},
+
 	-- Default algoritme (server kan runtime wisselen via State.MazeAlgorithm)
         MazeAlgorithm = "DFS", -- "DFS" of "PRIM"
         -- Kans (0-1) dat een bestaande muur na generatie alsnog wordt verwijderd om lussen te maken.

--- a/src/ServerScriptService/GameManager.server.lua
+++ b/src/ServerScriptService/GameManager.server.lua
@@ -717,6 +717,30 @@ local function finalizeStatsForPlayer(plr, roundFinishTime)
         return stats
 end
 
+local function ensureLeaderstats(plr)
+        local ls = plr:FindFirstChild("leaderstats")
+        if not ls then
+                ls = Instance.new("Folder")
+                ls.Name = "leaderstats"
+                ls.Parent = plr
+        end
+        if not ls:FindFirstChild("Coins") then
+                local v = Instance.new("IntValue")
+                v.Name = "Coins"
+                v.Parent = ls
+        end
+        if not ls:FindFirstChild("XP") then
+                local v = Instance.new("IntValue")
+                v.Name = "XP"
+                v.Parent = ls
+        end
+        if not ls:FindFirstChild("Escapes") then
+                local v = Instance.new("IntValue")
+                v.Name = "Escapes"
+                v.Parent = ls
+        end
+end
+
 local function quantize(amount)
         amount = tonumber(amount) or 0
         if amount >= 0 then
@@ -1030,14 +1054,6 @@ end
 _G.GameEliminatePlayer = eliminatePlayer
 
 -- Teleport characters to sky lobby on spawn during PREP/wait
-local function ensureLeaderstats(plr)
-        local ls = plr:FindFirstChild("leaderstats")
-        if not ls then ls = Instance.new("Folder"); ls.Name = "leaderstats"; ls.Parent = plr end
-        if not ls:FindFirstChild("Coins") then local v = Instance.new("IntValue"); v.Name = "Coins"; v.Parent = ls end
-        if not ls:FindFirstChild("XP") then local v = Instance.new("IntValue"); v.Name = "XP"; v.Parent = ls end
-        if not ls:FindFirstChild("Escapes") then local v = Instance.new("IntValue"); v.Name = "Escapes"; v.Parent = ls end
-end
-
 local function onCharacterAdded(plr, char)
         task.wait(0.1)
         local hrp = char:WaitForChild("HumanoidRootPart")

--- a/src/ServerScriptService/ProgressionService.lua
+++ b/src/ServerScriptService/ProgressionService.lua
@@ -1,0 +1,144 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ServerScriptService = game:GetService("ServerScriptService")
+
+local Config = require(ReplicatedStorage:WaitForChild("Modules"):WaitForChild("RoundConfig"))
+local InventoryProvider = require(ServerScriptService:WaitForChild("InventoryProvider"))
+
+local ProgressionService = {}
+local playerUnlockState = {}
+
+local function ensureEntry(plr)
+        if not plr then
+                return nil, nil
+        end
+        local userId = plr.UserId
+        if not userId or userId == 0 then
+                return nil, nil
+        end
+        local entry = playerUnlockState[userId]
+        if not entry then
+                entry = {
+                        granted = {},
+                }
+                playerUnlockState[userId] = entry
+        end
+        return entry, userId
+end
+
+local function applyUnlockReward(plr, unlockConfig)
+        local inventory = InventoryProvider.getInventory()
+        if not inventory then
+                return
+        end
+        local reward = unlockConfig.Reward or unlockConfig.reward
+        if reward == "ExitFinder" and type(inventory.GrantExitFinder) == "function" then
+                inventory.GrantExitFinder(plr)
+        elseif reward == "HunterFinder" and type(inventory.GrantHunterFinder) == "function" then
+                inventory.GrantHunterFinder(plr)
+        elseif reward == "KeyFinder" and type(inventory.GrantKeyFinder) == "function" then
+                inventory.GrantKeyFinder(plr)
+        end
+end
+
+local function evaluateUnlocks(plr, coinsAmount, xpAmount)
+        local entry = ensureEntry(plr)
+        if not entry then
+                return {}
+        end
+        local unlocksConfig = Config.Rewards and Config.Rewards.Unlocks
+        if type(unlocksConfig) ~= "table" then
+                return {}
+        end
+        coinsAmount = tonumber(coinsAmount) or 0
+        xpAmount = tonumber(xpAmount) or 0
+        local grantedNow = {}
+        for index, unlock in ipairs(unlocksConfig) do
+                if type(unlock) == "table" then
+                        local id = unlock.Id or unlock.id or unlock.Name or unlock.name or ("Unlock_" .. tostring(index))
+                        if not entry.granted[id] then
+                                local coinRequirement = tonumber(unlock.Coins or unlock.coins) or 0
+                                local xpRequirement = tonumber(unlock.XP or unlock.xp) or 0
+                                if coinsAmount >= coinRequirement and xpAmount >= xpRequirement then
+                                        entry.granted[id] = true
+                                        applyUnlockReward(plr, unlock)
+                                        table.insert(grantedNow, {
+                                                id = id,
+                                                name = unlock.Name or unlock.DisplayName or unlock.Label or id,
+                                                description = unlock.Description or unlock.description,
+                                        })
+                                end
+                        end
+                end
+        end
+        return grantedNow
+end
+
+function ProgressionService.AwardCurrency(plr, coinsDelta, xpDelta)
+        local entry = ensureEntry(plr)
+        if not entry then
+                return { coins = 0, xp = 0, unlocks = {} }
+        end
+        local leaderstats = plr:FindFirstChild("leaderstats")
+        if not leaderstats then
+                return { coins = 0, xp = 0, unlocks = {} }
+        end
+        local coinsValue = leaderstats:FindFirstChild("Coins")
+        local xpValue = leaderstats:FindFirstChild("XP")
+        if not coinsValue or not xpValue then
+                return { coins = 0, xp = 0, unlocks = {} }
+        end
+
+        coinsDelta = math.floor(tonumber(coinsDelta) or 0)
+        xpDelta = math.floor(tonumber(xpDelta) or 0)
+
+        if coinsDelta ~= 0 then
+                coinsValue.Value = coinsValue.Value + coinsDelta
+        end
+        if xpDelta ~= 0 then
+                xpValue.Value = xpValue.Value + xpDelta
+        end
+
+        local unlocks = evaluateUnlocks(plr, coinsValue.Value, xpValue.Value)
+        return {
+                coins = coinsDelta,
+                xp = xpDelta,
+                unlocks = unlocks,
+        }
+end
+
+local function onLeaderstatsReady(plr, leaderstats)
+        local coins = leaderstats:FindFirstChild("Coins")
+        local xp = leaderstats:FindFirstChild("XP")
+        if not coins or not xp then
+                return
+        end
+        coins:GetPropertyChangedSignal("Value"):Connect(function()
+                evaluateUnlocks(plr, coins.Value, xp.Value)
+        end)
+        xp:GetPropertyChangedSignal("Value"):Connect(function()
+                evaluateUnlocks(plr, coins.Value, xp.Value)
+        end)
+        evaluateUnlocks(plr, coins.Value, xp.Value)
+end
+
+Players.PlayerAdded:Connect(function(plr)
+        ensureEntry(plr)
+        task.defer(function()
+                local leaderstats = plr:WaitForChild("leaderstats", 60)
+                if leaderstats then
+                        onLeaderstatsReady(plr, leaderstats)
+                end
+        end)
+end)
+
+Players.PlayerRemoving:Connect(function(plr)
+        local _, userId = ensureEntry(plr)
+        if userId then
+                playerUnlockState[userId] = nil
+        end
+end)
+
+shared.ProgressionService = ProgressionService
+
+return ProgressionService

--- a/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
@@ -275,6 +275,15 @@ local function formatContribution(entry)
                 if details.seconds then
                         local seconds = math.floor((details.seconds or 0) + 0.5)
                         text = string.format("%s (%ds)", text, seconds)
+                elseif details.cells then
+                        local cells = math.floor((tonumber(details.cells) or 0) + 0.5)
+                        local total = tonumber(details.total)
+                        if total and total > 0 then
+                                local roundedTotal = math.floor(total + 0.5)
+                                text = string.format("%s (%d/%d tegels)", text, cells, roundedTotal)
+                        else
+                                text = string.format("%s (%d tegels)", text, cells)
+                        end
                 elseif details.count then
                         text = string.format("%s (x%d)", text, details.count)
                 end

--- a/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
@@ -209,7 +209,6 @@ rewardFeedFrame.BackgroundTransparency = 0.25
 rewardFeedFrame.BackgroundColor3 = Color3.fromRGB(20, 20, 28)
 rewardFeedFrame.BorderSizePixel = 0
 rewardFeedFrame.Visible = false
-rewardFeedFrame.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
 rewardFeedFrame.ZIndex = 5
 rewardFeedFrame.Parent = gui
 

--- a/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
@@ -10,6 +10,7 @@ local Pickup = Remotes:WaitForChild("Pickup")
 local DoorOpened = Remotes:WaitForChild("DoorOpened")
 local AliveStatus = Remotes:WaitForChild("AliveStatus")
 local PlayerEliminatedRemote = Remotes:WaitForChild("PlayerEliminated")
+local RoundRewardsRemote = Remotes:WaitForChild("RoundRewards")
 local EventMonsterEffects = Remotes:WaitForChild("EventMonsterEffects")
 local State = game.ReplicatedStorage:WaitForChild("State")
 local RoundConfig = require(game.ReplicatedStorage.Modules.RoundConfig)
@@ -197,6 +198,156 @@ eventWarningLabel.Parent = eventWarningFrame
 
 local defaultEventWarningColor = eventWarningFrame.BackgroundColor3
 local eventWarningToken
+
+local rewardFeedFrame = Instance.new("Frame")
+rewardFeedFrame.Name = "RoundRewardFeed"
+rewardFeedFrame.AnchorPoint = Vector2.new(1, 1)
+rewardFeedFrame.Position = UDim2.new(1, -30, 1, -40)
+rewardFeedFrame.Size = UDim2.new(0, 340, 0, 0)
+rewardFeedFrame.AutomaticSize = Enum.AutomaticSize.Y
+rewardFeedFrame.BackgroundTransparency = 0.25
+rewardFeedFrame.BackgroundColor3 = Color3.fromRGB(20, 20, 28)
+rewardFeedFrame.BorderSizePixel = 0
+rewardFeedFrame.Visible = false
+rewardFeedFrame.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
+rewardFeedFrame.ZIndex = 5
+rewardFeedFrame.Parent = gui
+
+local rewardCorner = Instance.new("UICorner")
+rewardCorner.CornerRadius = UDim.new(0, 12)
+rewardCorner.Parent = rewardFeedFrame
+
+local rewardStroke = Instance.new("UIStroke")
+rewardStroke.ApplyStrokeMode = Enum.ApplyStrokeMode.Border
+rewardStroke.Color = Color3.fromRGB(130, 160, 255)
+rewardStroke.Thickness = 1.5
+rewardStroke.Parent = rewardFeedFrame
+
+local rewardPadding = Instance.new("UIPadding")
+rewardPadding.PaddingTop = UDim.new(0, 10)
+rewardPadding.PaddingBottom = UDim.new(0, 10)
+rewardPadding.PaddingLeft = UDim.new(0, 12)
+rewardPadding.PaddingRight = UDim.new(0, 12)
+rewardPadding.Parent = rewardFeedFrame
+
+local rewardLayout = Instance.new("UIListLayout")
+rewardLayout.SortOrder = Enum.SortOrder.LayoutOrder
+rewardLayout.Padding = UDim.new(0, 6)
+rewardLayout.Parent = rewardFeedFrame
+
+local rewardDisplayToken = 0
+
+local function clearRewardDisplay()
+        rewardDisplayToken += 1
+        rewardFeedFrame.Visible = false
+        for _, child in ipairs(rewardFeedFrame:GetChildren()) do
+                if child:IsA("TextLabel") then
+                        child:Destroy()
+                end
+        end
+end
+
+local function createRewardLabel(text, color, layoutOrder)
+        local label = Instance.new("TextLabel")
+        label.Name = "RewardLine"
+        label.LayoutOrder = layoutOrder or 0
+        label.AutomaticSize = Enum.AutomaticSize.Y
+        label.Size = UDim2.new(1, 0, 0, 20)
+        label.BackgroundTransparency = 1
+        label.Font = Enum.Font.GothamSemibold
+        label.TextScaled = true
+        label.TextWrapped = true
+        label.TextXAlignment = Enum.TextXAlignment.Left
+        label.TextYAlignment = Enum.TextYAlignment.Center
+        label.TextColor3 = color or Color3.fromRGB(235, 235, 235)
+        label.Text = text
+        label.Parent = rewardFeedFrame
+        return label
+end
+
+local function formatContribution(entry)
+        local coins = tonumber(entry.coins) or 0
+        local xp = tonumber(entry.xp) or 0
+        local label = entry.label or "Bonus"
+        local text = string.format("+%d munten / +%d XP — %s", coins, xp, label)
+        local details = entry.details
+        if details then
+                if details.seconds then
+                        local seconds = math.floor((details.seconds or 0) + 0.5)
+                        text = string.format("%s (%ds)", text, seconds)
+                elseif details.count then
+                        text = string.format("%s (x%d)", text, details.count)
+                end
+        end
+        return text
+end
+
+local function showRoundRewards(data)
+        clearRewardDisplay()
+        if not data then
+                return
+        end
+        local token = rewardDisplayToken
+        rewardFeedFrame.Visible = true
+
+        local finalState = tostring(data.finalState or "")
+        if finalState ~= "" then
+                local stateText
+                local stateColor = Color3.fromRGB(235, 235, 235)
+                if finalState == "Escaped" then
+                        stateText = "Status: Ontsnapt!"
+                        stateColor = Color3.fromRGB(170, 255, 170)
+                elseif finalState == "Survived" then
+                        stateText = "Status: Overleefd"
+                        stateColor = Color3.fromRGB(150, 220, 255)
+                elseif finalState == "Eliminated" then
+                        stateText = "Status: Uitgeschakeld"
+                        stateColor = Color3.fromRGB(255, 150, 150)
+                else
+                        stateText = "Status: Onbekend"
+                end
+                createRewardLabel(stateText, stateColor, 0)
+        end
+
+        local totalCoins = tonumber(data.totalCoins or data.coins) or 0
+        local totalXP = tonumber(data.totalXP or data.xp) or 0
+        createRewardLabel(string.format("Totale beloning: +%d munten / +%d XP", totalCoins, totalXP), Color3.fromRGB(255, 240, 180), 1)
+
+        local contributions = {}
+        if typeof(data.contributions) == "table" then
+                contributions = data.contributions
+        end
+
+        if #contributions > 0 then
+                createRewardLabel("Details:", Color3.fromRGB(200, 210, 255), 2)
+                for index, entry in ipairs(contributions) do
+                        createRewardLabel(formatContribution(entry), Color3.fromRGB(235, 235, 235), 10 + index)
+                end
+        else
+                createRewardLabel("Geen individuele bonussen deze ronde.", Color3.fromRGB(210, 210, 210), 2)
+        end
+
+        local unlocks = {}
+        if typeof(data.unlocks) == "table" then
+                unlocks = data.unlocks
+        end
+        if #unlocks > 0 then
+                createRewardLabel("Nieuwe ontgrendelingen:", Color3.fromRGB(170, 255, 170), 100)
+                for index, unlock in ipairs(unlocks) do
+                        local unlockText = unlock.name or unlock.id or "Ontgrendeling"
+                        if unlock.description and unlock.description ~= "" then
+                                unlockText = string.format("%s – %s", unlockText, unlock.description)
+                        end
+                        createRewardLabel(unlockText, Color3.fromRGB(180, 255, 190), 100 + index)
+                end
+        end
+
+        task.delay(8, function()
+                if rewardDisplayToken == token then
+                        clearRewardDisplay()
+                end
+        end)
+end
 
 local currentEventStatus = "Onbekend"
 local eventStatusValue
@@ -891,6 +1042,9 @@ task.defer(connectExitPadListener)
 
 RoundState.OnClientEvent:Connect(function(state)
         currentRoundState = tostring(state)
+        if currentRoundState == "PREP" then
+                clearRewardDisplay()
+        end
         if currentRoundState ~= "ACTIVE" and eliminationCameraToken then
                 resetEliminationCamera(eliminationCameraToken)
         end
@@ -923,6 +1077,7 @@ PlayerEliminatedRemote.OnClientEvent:Connect(function(info)
                 playEliminationSequence(info.position)
         end
 end)
+RoundRewardsRemote.OnClientEvent:Connect(showRoundRewards)
 Pickup.OnClientEvent:Connect(function(item)
         playUISound(SOUND_IDS.Pickup)
 


### PR DESCRIPTION
## Summary
- track per-round performance in the game manager, award coins/xp via a new RoundRewards remote, and integrate a progression service hook
- expose configurable reward and unlock values in RoundConfig and add a dedicated ProgressionService for inventory unlocks
- update the client HUD to surface reward breakdowns and new unlock notifications

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7e697c2a083229faa301db34fac66