### PR TITLE
Add theme-driven lobby activity system

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -46,6 +46,9 @@
         "StartGameRequest": {
           "$className": "RemoteEvent"
         },
+        "StartThemeCountdown": {
+          "$className": "RemoteEvent"
+        },
         "ThemeVote": {
           "$className": "RemoteEvent"
         },

--- a/default.project.json
+++ b/default.project.json
@@ -37,6 +37,9 @@
         "LobbyState": {
           "$className": "RemoteEvent"
         },
+        "LobbyActivityUpdate": {
+          "$className": "RemoteEvent"
+        },
         "ToggleReady": {
           "$className": "RemoteEvent"
         },

--- a/src/ReplicatedStorage/Modules/RoundConfig.lua
+++ b/src/ReplicatedStorage/Modules/RoundConfig.lua
@@ -116,12 +116,12 @@ local Config = {
 
 	-- Beloningsconfiguratie: ontwerpers kunnen deze waarden aanpassen zonder scripts te wijzigen.
 	-- Coins/XP zijn gehele bedragen; per-seconde/-actie waarden worden afgerond op hele nummers.
-	Rewards = {
-		Participation = {
-			Coins = 15,
-			XP = 20,
-			Description = "Basistoelage voor spelers die bij de start van de ronde aanwezig waren.",
-		},
+        Rewards = {
+                Participation = {
+                        Coins = 15,
+                        XP = 20,
+                        Description = "Basistoelage voor spelers die bij de start van de ronde aanwezig waren.",
+                },
 		Survival = {
 			CoinsPerSecond = 0.4,
 			XPPerSecond = 0.9,
@@ -169,10 +169,47 @@ local Config = {
 				XP = 550,
 				Description = "Ontgrendelt de Key Finder gadget in de inventaris.",
 			},
-		},
-	},
+                },
+        },
 
-	-- Default algoritme (server kan runtime wisselen via State.MazeAlgorithm)
+        LobbyActivities = {
+                Parkour = {
+                        DisplayName = "Parkour Parcours",
+                        Description = "Ren en spring over obstakels totdat je de finish haalt.",
+                        ThemeIds = { "Spooky" },
+                        Reward = { Coins = 20, XP = 30 },
+                        WaypointPosition = Vector3.new(0, 5, -60),
+                        PromptActionText = "Voltooi parkour",
+                        HoldDuration = 1.5,
+                },
+                Puzzle = {
+                        DisplayName = "Puzzelhoek",
+                        Description = "Los de lichtpuzzel op door de juiste tegels te activeren.",
+                        ThemeIds = { "Frost" },
+                        Reward = { Coins = 18, XP = 28 },
+                        WaypointPosition = Vector3.new(48, 5, 0),
+                        PromptActionText = "Los puzzel op",
+                        HoldDuration = 1.5,
+                },
+                Minigame = {
+                        DisplayName = "Minigame Arena",
+                        Description = "Doe mee aan een snelle minigame-uitdaging voor extra beloningen.",
+                        ThemeIds = { "Jungle", "Glaze" },
+                        Reward = { Coins = 16, XP = 24 },
+                        WaypointPosition = Vector3.new(-48, 5, 0),
+                        PromptActionText = "Start minigame",
+                        HoldDuration = 1.5,
+                },
+        },
+
+        LobbyActivityDefaults = {
+                CompletionCooldown = 15,
+                ResetDelay = 4,
+                Reward = { Coins = 12, XP = 18 },
+                DefaultZone = "Minigame",
+        },
+
+        -- Default algoritme (server kan runtime wisselen via State.MazeAlgorithm)
         MazeAlgorithm = "DFS", -- "DFS" of "PRIM"
         -- Kans (0-1) dat een bestaande muur na generatie alsnog wordt verwijderd om lussen te maken.
         LoopChance = 0.05,

--- a/src/ServerScriptService/EnsureLobbyBoard.server.lua
+++ b/src/ServerScriptService/EnsureLobbyBoard.server.lua
@@ -554,11 +554,85 @@ local function ensureLobbyBoard()
             end
         end
 
+        local countdownPanelExisting = existing:FindFirstChild("CountdownPanel")
+        if not countdownPanelExisting then
+            countdownPanelExisting = Instance.new("Part")
+            countdownPanelExisting.Name = "CountdownPanel"
+            countdownPanelExisting.Anchored = true
+            countdownPanelExisting.CanCollide = false
+            countdownPanelExisting.CastShadow = false
+            countdownPanelExisting.Material = Enum.Material.SmoothPlastic
+            countdownPanelExisting.Color = Color3.fromRGB(28, 32, 50)
+            countdownPanelExisting.Size = Vector3.new(1.4, math.max(1.6, boardHeight * 0.22), 0.35)
+            countdownPanelExisting.Parent = existing
+        end
+
+        local countdownButtonExisting = existing:FindFirstChild("CountdownButton")
+        if not countdownButtonExisting then
+            countdownButtonExisting = Instance.new("Part")
+            countdownButtonExisting.Name = "CountdownButton"
+            countdownButtonExisting.Anchored = true
+            countdownButtonExisting.CanCollide = false
+            countdownButtonExisting.CastShadow = false
+            countdownButtonExisting.Size = Vector3.new(0.7, 0.7, 0.24)
+            countdownButtonExisting.Material = Enum.Material.Neon
+            countdownButtonExisting.Color = Color3.fromRGB(140, 196, 255)
+            countdownButtonExisting.Parent = existing
+        end
+
+        if countdownButtonExisting then
+            if not countdownButtonExisting:FindFirstChild("CountdownPrompt") then
+                local countdownPrompt = createPrompt(countdownButtonExisting, "CountdownPrompt", "Start aftellen", "Aftelknop", Enum.KeyCode.G, 0, Vector2.new(0, -4))
+                countdownPrompt.GamepadKeyCode = Enum.KeyCode.ButtonB
+            end
+
+            if not countdownButtonExisting:FindFirstChild("CountdownClick") then
+                local countdownClickDetector = Instance.new("ClickDetector")
+                countdownClickDetector.Name = "CountdownClick"
+                countdownClickDetector.MaxActivationDistance = 14
+                countdownClickDetector.Parent = countdownButtonExisting
+            end
+
+            local countdownGui = countdownButtonExisting:FindFirstChild("ButtonLabel")
+            if not countdownGui or not countdownGui:IsA("SurfaceGui") then
+                if countdownGui then
+                    countdownGui:Destroy()
+                end
+                countdownGui = Instance.new("SurfaceGui")
+                countdownGui.Name = "ButtonLabel"
+                countdownGui.Face = Enum.NormalId.Front
+                countdownGui.SizingMode = Enum.SurfaceGuiSizingMode.PixelsPerStud
+                countdownGui.PixelsPerStud = 80
+                countdownGui.LightInfluence = 0
+                countdownGui.Adornee = countdownButtonExisting
+                countdownGui.ResetOnSpawn = false
+                countdownGui.Parent = countdownButtonExisting
+            end
+
+            local label = countdownGui:FindFirstChild("Label")
+            if not label or not label:IsA("TextLabel") then
+                if label then
+                    label:Destroy()
+                end
+                label = createTextLabel(countdownGui, "Label", "AFTELLING", UDim2.new(1, 0, 1, 0), UDim2.new(), {
+                    Font = Enum.Font.GothamBlack,
+                    TextColor3 = Color3.fromRGB(18, 24, 36),
+                    TextScaled = true,
+                })
+            else
+                label.Text = "AFTELLING"
+                label.TextColor3 = Color3.fromRGB(18, 24, 36)
+                label.Font = Enum.Font.GothamBlack
+            end
+        end
+
         return lobby, existing, {
             playerStand = playerStandExisting,
             themeStand = themeStandExisting,
             startPanel = startPanelExisting,
             startButton = startButtonExisting,
+            countdownPanel = countdownPanelExisting,
+            countdownButton = countdownButtonExisting,
             billboardAnchor = existing:FindFirstChild("BillboardAnchor"),
         }
     end
@@ -610,6 +684,26 @@ local function ensureLobbyBoard()
     startButton.Material = Enum.Material.Neon
     startButton.Color = Color3.fromRGB(255, 183, 72)
     startButton.Parent = boardModel
+
+    local countdownPanel = Instance.new("Part")
+    countdownPanel.Name = "CountdownPanel"
+    countdownPanel.Anchored = true
+    countdownPanel.CanCollide = false
+    countdownPanel.CastShadow = false
+    countdownPanel.Material = Enum.Material.SmoothPlastic
+    countdownPanel.Color = Color3.fromRGB(28, 32, 50)
+    countdownPanel.Size = Vector3.new(1.4, math.max(1.6, boardHeight * 0.22), 0.35)
+    countdownPanel.Parent = boardModel
+
+    local countdownButton = Instance.new("Part")
+    countdownButton.Name = "CountdownButton"
+    countdownButton.Anchored = true
+    countdownButton.CanCollide = false
+    countdownButton.CastShadow = false
+    countdownButton.Size = Vector3.new(0.7, 0.7, 0.24)
+    countdownButton.Material = Enum.Material.Neon
+    countdownButton.Color = Color3.fromRGB(140, 196, 255)
+    countdownButton.Parent = boardModel
 
     local playerSurface = createSurface(playerStand, "PlayerSurface")
     local playerBoard = createFrame(playerSurface, "PlayerBoard", UDim2.new(1, 0, 1, 0), UDim2.new(), {
@@ -825,6 +919,14 @@ local function ensureLobbyBoard()
     startClickDetector.MaxActivationDistance = 14
     startClickDetector.Parent = startButton
 
+    local countdownPrompt = createPrompt(countdownButton, "CountdownPrompt", "Start aftellen", "Aftelknop", Enum.KeyCode.G, 0, Vector2.new(0, -4))
+    countdownPrompt.GamepadKeyCode = Enum.KeyCode.ButtonB
+
+    local countdownClickDetector = Instance.new("ClickDetector")
+    countdownClickDetector.Name = "CountdownClick"
+    countdownClickDetector.MaxActivationDistance = 14
+    countdownClickDetector.Parent = countdownButton
+
     local buttonGui = Instance.new("SurfaceGui")
     buttonGui.Name = "ButtonLabel"
     buttonGui.Face = Enum.NormalId.Front
@@ -838,6 +940,22 @@ local function ensureLobbyBoard()
     local buttonLabel = createTextLabel(buttonGui, "Label", "START", UDim2.new(1, 0, 1, 0), UDim2.new(), {
         Font = Enum.Font.GothamBlack,
         TextColor3 = Color3.fromRGB(30, 30, 34),
+        TextScaled = true,
+    })
+
+    local countdownGui = Instance.new("SurfaceGui")
+    countdownGui.Name = "ButtonLabel"
+    countdownGui.Face = Enum.NormalId.Front
+    countdownGui.SizingMode = Enum.SurfaceGuiSizingMode.PixelsPerStud
+    countdownGui.PixelsPerStud = 80
+    countdownGui.LightInfluence = 0
+    countdownGui.Adornee = countdownButton
+    countdownGui.ResetOnSpawn = false
+    countdownGui.Parent = countdownButton
+
+    local countdownLabel = createTextLabel(countdownGui, "Label", "AFTELLING", UDim2.new(1, 0, 1, 0), UDim2.new(), {
+        Font = Enum.Font.GothamBlack,
+        TextColor3 = Color3.fromRGB(18, 24, 36),
         TextScaled = true,
     })
 
@@ -857,6 +975,8 @@ local function ensureLobbyBoard()
         themeStand = themeStand,
         startPanel = startPanel,
         startButton = startButton,
+        countdownPanel = countdownPanel,
+        countdownButton = countdownButton,
         billboardAnchor = billboardAnchor,
     }
 end
@@ -870,9 +990,11 @@ local playerStand = components.playerStand
 local themeStand = components.themeStand
 local startPanel = components.startPanel
 local startButton = components.startButton
+local countdownPanel = components.countdownPanel
+local countdownButton = components.countdownButton
 local billboardAnchor = components.billboardAnchor
 
-if not playerStand or not themeStand or not startPanel or not startButton then
+if not playerStand or not themeStand or not startPanel or not startButton or not countdownPanel or not countdownButton then
     return
 end
 
@@ -882,6 +1004,7 @@ local playerWidth = 6.5 * boardWidthScale
 local themeWidth = 6.25 * boardWidthScale
 local startButtonBaseGap = 0.9
 local startButtonMinGap = 0.3
+local countdownButtonGap = 0.9
 
 local function clamp(value, minValue, maxValue)
     if minValue > maxValue then
@@ -1007,6 +1130,7 @@ local function updateBoardPlacement()
     playerStand.Size = Vector3.new(playerWidth, boardHeight, boardThickness)
     themeStand.Size = Vector3.new(themeWidth, boardHeight, boardThickness)
     startPanel.Size = Vector3.new(startPanel.Size.X, math.max(1.6, boardHeight * 0.22), startPanel.Size.Z)
+    countdownPanel.Size = Vector3.new(countdownPanel.Size.X, math.max(1.6, boardHeight * 0.22), countdownPanel.Size.Z)
 
     local lobbyBase = trackedLobbyBase
     if not lobbyBase or not lobbyBase.Parent then
@@ -1040,6 +1164,11 @@ local function updateBoardPlacement()
     local buttonHeightOffset = 0
     startPanel.CFrame = pivot * CFrame.new(buttonOffsetX, buttonHeightOffset, buttonDepth)
     startButton.CFrame = startPanel.CFrame * CFrame.new(0, 0, -(startPanel.Size.Z * 0.5 + startButton.Size.Z * 0.5 - 0.01))
+
+    local countdownDepth = -(playerStand.Size.Z * 0.5 - countdownPanel.Size.Z * 0.5 - 0.02)
+    local countdownOffsetX = -(playerStand.Size.X * 0.5 + boardSpacing + themeStand.Size.X + countdownPanel.Size.X * 0.5 + countdownButtonGap)
+    countdownPanel.CFrame = pivot * CFrame.new(countdownOffsetX, 0, countdownDepth)
+    countdownButton.CFrame = countdownPanel.CFrame * CFrame.new(0, 0, -(countdownPanel.Size.Z * 0.5 + countdownButton.Size.Z * 0.5 - 0.01))
 
     boardModel.PrimaryPart = playerStand
     boardModel:PivotTo(pivot)

--- a/src/ServerScriptService/LobbyActivityService.server.lua
+++ b/src/ServerScriptService/LobbyActivityService.server.lua
@@ -1,0 +1,493 @@
+local Players = game:GetService("Players")
+local Workspace = game:GetService("Workspace")
+local CollectionService = game:GetService("CollectionService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ServerScriptService = game:GetService("ServerScriptService")
+
+local Modules = ReplicatedStorage:WaitForChild("Modules")
+local ThemeConfig = require(Modules:WaitForChild("ThemeConfig"))
+local RoundConfig = require(Modules:WaitForChild("RoundConfig"))
+local ProgressionService = require(ServerScriptService:WaitForChild("ProgressionService"))
+
+local Remotes = ReplicatedStorage:WaitForChild("Remotes")
+local ActivityUpdateRemote = Remotes:FindFirstChild("LobbyActivityUpdate")
+if not ActivityUpdateRemote then
+        ActivityUpdateRemote = Instance.new("RemoteEvent")
+        ActivityUpdateRemote.Name = "LobbyActivityUpdate"
+        ActivityUpdateRemote.Parent = Remotes
+end
+
+local State = ReplicatedStorage:WaitForChild("State")
+local ThemeValue = State:WaitForChild("Theme")
+
+local lobbyFolder = Workspace:FindFirstChild("Lobby")
+if not lobbyFolder then
+        lobbyFolder = Instance.new("Folder")
+        lobbyFolder.Name = "Lobby"
+        lobbyFolder.Parent = Workspace
+end
+
+local activityZonesFolder = lobbyFolder:FindFirstChild("ActivityZones")
+if not activityZonesFolder then
+        activityZonesFolder = Instance.new("Folder")
+        activityZonesFolder.Name = "ActivityZones"
+        activityZonesFolder.Parent = lobbyFolder
+end
+
+local ActivityConfig = RoundConfig.LobbyActivities or {}
+local ActivityDefaults = RoundConfig.LobbyActivityDefaults or {}
+ActivityDefaults.Reward = ActivityDefaults.Reward or { Coins = 12, XP = 18 }
+ActivityDefaults.CompletionCooldown = tonumber(ActivityDefaults.CompletionCooldown) or 15
+ActivityDefaults.ResetDelay = tonumber(ActivityDefaults.ResetDelay) or 4
+ActivityDefaults.DefaultZone = ActivityDefaults.DefaultZone or "Minigame"
+ActivityDefaults.HoldDuration = tonumber(ActivityDefaults.HoldDuration) or 1.5
+
+if not next(ActivityConfig) then
+        ActivityConfig = {
+                Parkour = {
+                        DisplayName = "Parkour Parcours",
+                        Description = "Ren en spring over obstakels totdat je de finish haalt.",
+                        ThemeIds = { "Spooky" },
+                        Reward = { Coins = 20, XP = 30 },
+                        WaypointPosition = Vector3.new(0, 5, -60),
+                        PromptActionText = "Voltooi parkour",
+                        HoldDuration = 1.5,
+                },
+                Puzzle = {
+                        DisplayName = "Puzzelhoek",
+                        Description = "Los de lichtpuzzel op door de juiste tegels te activeren.",
+                        ThemeIds = { "Frost" },
+                        Reward = { Coins = 18, XP = 28 },
+                        WaypointPosition = Vector3.new(48, 5, 0),
+                        PromptActionText = "Los puzzel op",
+                        HoldDuration = 1.5,
+                },
+                Minigame = {
+                        DisplayName = "Minigame Arena",
+                        Description = "Doe mee aan een snelle minigame-uitdaging voor extra beloningen.",
+                        ThemeIds = { "Jungle", "Glaze" },
+                        Reward = { Coins = 16, XP = 24 },
+                        WaypointPosition = Vector3.new(-48, 5, 0),
+                        PromptActionText = "Start minigame",
+                        HoldDuration = 1.5,
+                },
+        }
+end
+
+local function hasTag(instance, tag)
+        local ok, result = pcall(function()
+                return CollectionService:HasTag(instance, tag)
+        end)
+        if ok then
+                return result
+        end
+        return false
+end
+
+local function addTag(instance, tag)
+        if instance and tag and tag ~= "" and not hasTag(instance, tag) then
+                CollectionService:AddTag(instance, tag)
+        end
+end
+
+local function applyTagsRecursive(instance, tags)
+        for _, tag in ipairs(tags) do
+                addTag(instance, tag)
+        end
+        for _, child in ipairs(instance:GetChildren()) do
+                applyTagsRecursive(child, tags)
+        end
+end
+
+local partState = setmetatable({}, { __mode = "k" })
+
+local function setPartActive(part, isActive)
+        local state = partState[part]
+        if not state then
+                state = {
+                        Transparency = part.Transparency,
+                        CanCollide = part.CanCollide,
+                        CanTouch = part.CanTouch,
+                        CanQuery = part.CanQuery,
+                        CastShadow = part.CastShadow,
+                        Material = part.Material,
+                        Color = part.Color,
+                }
+                partState[part] = state
+                part.Destroying:Connect(function()
+                        partState[part] = nil
+                end)
+        end
+        if isActive then
+                part.Transparency = state.Transparency
+                part.CanCollide = state.CanCollide
+                part.CanTouch = state.CanTouch
+                part.CanQuery = state.CanQuery
+                part.CastShadow = state.CastShadow
+                part.Material = state.Material
+                part.Color = state.Color
+        else
+                part.Transparency = 1
+                part.CanCollide = false
+                part.CanTouch = false
+                part.CanQuery = false
+                part.CastShadow = false
+        end
+end
+
+local function setInstanceEnabled(instance, isActive)
+        if instance:IsA("ParticleEmitter") or instance:IsA("Beam") or instance:IsA("Trail") then
+                instance.Enabled = isActive
+        elseif instance:IsA("PointLight") or instance:IsA("SpotLight") or instance:IsA("SurfaceLight") then
+                instance.Enabled = isActive
+        elseif instance:IsA("BillboardGui") or instance:IsA("SurfaceGui") then
+                instance.Enabled = isActive
+        elseif instance:IsA("Sound") then
+                if isActive then
+                        if not instance.Playing then
+                                instance:Play()
+                        end
+                else
+                        instance:Stop()
+                end
+        elseif instance:IsA("ProximityPrompt") then
+                instance.Enabled = isActive
+        end
+end
+
+local function setContainerActive(container, isActive)
+        if container.SetAttribute then
+                container:SetAttribute("Active", isActive)
+        end
+        for _, descendant in ipairs(container:GetDescendants()) do
+                if descendant:IsA("BasePart") then
+                        setPartActive(descendant, isActive)
+                else
+                        setInstanceEnabled(descendant, isActive)
+                end
+        end
+end
+
+local zoneData = {}
+local themeToZone = {}
+local playerCooldowns = {}
+
+local handleCompletion
+
+local function getThemeDisplayName(themeId)
+        local theme = ThemeConfig.Get(themeId)
+        if theme and theme.displayName then
+                return theme.displayName
+        end
+        return themeId
+end
+
+local function ensureZone(zoneName, config)
+        local zoneFolder = activityZonesFolder:FindFirstChild(zoneName)
+        if not zoneFolder then
+                zoneFolder = Instance.new("Folder")
+                zoneFolder.Name = zoneName
+                zoneFolder.Parent = activityZonesFolder
+        end
+        zoneFolder:SetAttribute("ZoneId", zoneName)
+        addTag(zoneFolder, "LobbyActivityZone")
+
+        local waypoint = zoneFolder:FindFirstChild("Waypoint")
+        if not waypoint or not waypoint:IsA("BasePart") then
+                if waypoint then
+                        waypoint:Destroy()
+                end
+                waypoint = Instance.new("Part")
+                waypoint.Name = "Waypoint"
+                waypoint.Size = Vector3.new(3, 3, 3)
+                waypoint.Anchored = true
+                waypoint.CanCollide = false
+                waypoint.CanTouch = false
+                waypoint.CanQuery = false
+                waypoint.Transparency = 1
+                waypoint.Parent = zoneFolder
+        end
+        local waypointPosition = config.WaypointPosition
+        if typeof(waypointPosition) == "Vector3" then
+                waypoint.Position = waypointPosition
+        end
+        waypoint:SetAttribute("ZoneId", zoneName)
+
+        local prompt = waypoint:FindFirstChildWhichIsA("ProximityPrompt")
+        if not prompt then
+                prompt = Instance.new("ProximityPrompt")
+                prompt.Name = "CompleteActivityPrompt"
+                prompt.RequiresLineOfSight = false
+                prompt.MaxActivationDistance = 12
+                prompt.Enabled = false
+                prompt.Style = Enum.ProximityPromptStyle.Default
+                prompt.Parent = waypoint
+        end
+        prompt:SetAttribute("ZoneId", zoneName)
+        prompt.ActionText = config.PromptActionText or ("Voltooi " .. string.lower(zoneName))
+        prompt.ObjectText = config.DisplayName or zoneName
+        prompt.HoldDuration = tonumber(config.HoldDuration) or ActivityDefaults.HoldDuration
+
+        local zoneTag = "LobbyZone_" .. zoneName
+        local assetFolders = {}
+        local themeIds = config.ThemeIds
+        if type(themeIds) == "table" then
+                local index = 0
+                for _, themeId in ipairs(themeIds) do
+                        if typeof(themeId) == "string" then
+                                index += 1
+                                themeToZone[themeId] = zoneName
+                                local folderName = themeId .. "Assets"
+                                local assetFolder = zoneFolder:FindFirstChild(folderName)
+                                if not assetFolder then
+                                        assetFolder = Instance.new("Folder")
+                                        assetFolder.Name = folderName
+                                        assetFolder.Parent = zoneFolder
+                                end
+                                assetFolder:SetAttribute("ZoneId", zoneName)
+                                assetFolder:SetAttribute("ThemeId", themeId)
+                                local themeTag = "LobbyTheme_" .. themeId
+                                applyTagsRecursive(assetFolder, { zoneTag, themeTag, "LobbyActivityAsset" })
+
+                                local pad = assetFolder:FindFirstChild("ActivityPad")
+                                if not pad or not pad:IsA("BasePart") then
+                                        if pad then
+                                                pad:Destroy()
+                                        end
+                                        pad = Instance.new("Part")
+                                        pad.Name = "ActivityPad"
+                                        pad.Anchored = true
+                                        pad.CanCollide = false
+                                        pad.CanTouch = false
+                                        pad.CanQuery = false
+                                        pad.Material = Enum.Material.Neon
+                                        pad.Transparency = 0.75
+                                        pad.Size = Vector3.new(10, 1, 10)
+                                        pad.Parent = assetFolder
+                                end
+
+                                local offset = Vector3.new((index - 1) * 12, -1, 0)
+                                pad.CFrame = CFrame.new(waypoint.Position + offset)
+
+                                local theme = ThemeConfig.Get(themeId)
+                                if theme and theme.primaryColor then
+                                        pad.Color = theme.primaryColor
+                                else
+                                        pad.Color = Color3.fromRGB(120, 120, 200)
+                                end
+
+                                applyTagsRecursive(pad, { zoneTag, themeTag, "LobbyActivityAsset" })
+                                setContainerActive(assetFolder, false)
+                                assetFolders[themeId] = assetFolder
+                        end
+                end
+        end
+
+        if not zoneData[zoneName] then
+                zoneData[zoneName] = {
+                        folder = zoneFolder,
+                        waypoint = waypoint,
+                        prompt = prompt,
+                        assetFolders = assetFolders,
+                        config = config,
+                }
+        else
+                zoneData[zoneName].assetFolders = assetFolders
+                zoneData[zoneName].config = config
+                zoneData[zoneName].prompt = prompt
+                zoneData[zoneName].waypoint = waypoint
+                zoneData[zoneName].folder = zoneFolder
+        end
+
+        prompt.Triggered:Connect(function(player)
+                if player and player:IsA("Player") and handleCompletion then
+                        handleCompletion(player, zoneName)
+                end
+        end)
+end
+
+for zoneName, config in pairs(ActivityConfig) do
+        ensureZone(zoneName, config)
+end
+
+local activeZoneName = nil
+local activeThemeId = nil
+
+local LobbyActivityService = {}
+
+local function sendActivityStateTo(player)
+        if not player or not activeZoneName then
+                return
+        end
+        local zoneState = zoneData[activeZoneName]
+        if not zoneState then
+                return
+        end
+        local rewardConfig = zoneState.config.Reward or ActivityDefaults.Reward or {}
+        local themeName = getThemeDisplayName(activeThemeId)
+        ActivityUpdateRemote:FireClient(player, {
+                action = "ActivityChanged",
+                zone = activeZoneName,
+                theme = activeThemeId,
+                themeDisplayName = themeName,
+                displayName = zoneState.config.DisplayName or activeZoneName,
+                description = zoneState.config.Description,
+                reward = {
+                        coins = rewardConfig.Coins or rewardConfig.coins or 0,
+                        xp = rewardConfig.XP or rewardConfig.xp or 0,
+                },
+        })
+end
+
+local function applyZoneState()
+        for zoneName, state in pairs(zoneData) do
+                local isActive = zoneName == activeZoneName
+                if state.folder then
+                        state.folder:SetAttribute("IsActive", isActive)
+                end
+                if state.prompt then
+                        state.prompt.Enabled = isActive
+                        if isActive then
+                                state.prompt.HoldDuration = tonumber(state.config.HoldDuration) or ActivityDefaults.HoldDuration
+                                state.prompt.ActionText = state.config.PromptActionText or state.prompt.ActionText
+                                local themeName = getThemeDisplayName(activeThemeId)
+                                state.prompt.ObjectText = string.format("%s (%s)", state.config.DisplayName or zoneName, themeName)
+                        end
+                end
+                for themeId, container in pairs(state.assetFolders) do
+                        local shouldActivate = isActive and themeId == activeThemeId
+                        setContainerActive(container, shouldActivate)
+                end
+        end
+end
+
+local function updateActiveFromTheme()
+        local themeId = ThemeValue.Value
+        if typeof(themeId) ~= "string" or themeId == "" then
+                themeId = ThemeConfig.Default
+        end
+        local nextZone = themeToZone[themeId] or ActivityDefaults.DefaultZone
+        if not nextZone or not zoneData[nextZone] then
+                for candidate in pairs(zoneData) do
+                        nextZone = candidate
+                        break
+                end
+        end
+        if not nextZone then
+                activeZoneName = nil
+                activeThemeId = themeId
+                return
+        end
+
+        local changed = nextZone ~= activeZoneName or themeId ~= activeThemeId
+        activeZoneName = nextZone
+        activeThemeId = themeId
+        applyZoneState()
+        if changed then
+                ActivityUpdateRemote:FireAllClients({
+                        action = "ActivityChanged",
+                        zone = activeZoneName,
+                        theme = activeThemeId,
+                        themeDisplayName = getThemeDisplayName(activeThemeId),
+                        displayName = zoneData[activeZoneName].config.DisplayName or activeZoneName,
+                        description = zoneData[activeZoneName].config.Description,
+                        reward = {
+                                coins = (zoneData[activeZoneName].config.Reward and (zoneData[activeZoneName].config.Reward.Coins or zoneData[activeZoneName].config.Reward.coins))
+                                        or (ActivityDefaults.Reward and (ActivityDefaults.Reward.Coins or ActivityDefaults.Reward.coins))
+                                        or 0,
+                                xp = (zoneData[activeZoneName].config.Reward and (zoneData[activeZoneName].config.Reward.XP or zoneData[activeZoneName].config.Reward.xp))
+                                        or (ActivityDefaults.Reward and (ActivityDefaults.Reward.XP or ActivityDefaults.Reward.xp))
+                                        or 0,
+                        },
+                })
+        end
+end
+
+handleCompletion = function(player, zoneName)
+        if zoneName ~= activeZoneName then
+                return
+        end
+        if not player or not player:IsA("Player") then
+                return
+        end
+        local zoneState = zoneData[zoneName]
+        if not zoneState then
+                return
+        end
+        local now = os.clock()
+        local record = playerCooldowns[player]
+        if not record then
+                record = {}
+                playerCooldowns[player] = record
+        end
+        local last = record[zoneName] or 0
+        if now - last < ActivityDefaults.CompletionCooldown then
+                return
+        end
+        record[zoneName] = now
+
+        local rewardConfig = zoneState.config.Reward or ActivityDefaults.Reward or {}
+        local coinsReward = rewardConfig.Coins or rewardConfig.coins or 0
+        local xpReward = rewardConfig.XP or rewardConfig.xp or 0
+        local applied = ProgressionService.AwardCurrency(player, coinsReward, xpReward) or { coins = 0, xp = 0, unlocks = {} }
+
+        ActivityUpdateRemote:FireClient(player, {
+                action = "RewardGranted",
+                zone = zoneName,
+                theme = activeThemeId,
+                themeDisplayName = getThemeDisplayName(activeThemeId),
+                displayName = zoneState.config.DisplayName or zoneName,
+                description = zoneState.config.Description,
+                reward = {
+                        coins = coinsReward,
+                        xp = xpReward,
+                },
+                applied = {
+                        coins = applied.coins or 0,
+                        xp = applied.xp or 0,
+                        unlocks = applied.unlocks or {},
+                },
+        })
+
+        local resetDelay = tonumber(zoneState.config.ResetDelay) or ActivityDefaults.ResetDelay
+        if zoneState.prompt and resetDelay > 0 then
+                local prompt = zoneState.prompt
+                prompt.Enabled = false
+                task.delay(resetDelay, function()
+                        if prompt.Parent and zoneName == activeZoneName then
+                                prompt.Enabled = true
+                        end
+                end)
+        end
+end
+
+LobbyActivityService.GetActiveZone = function()
+        return activeZoneName
+end
+
+LobbyActivityService.GetActiveTheme = function()
+        return activeThemeId
+end
+
+LobbyActivityService.HandleCompletion = handleCompletion
+
+shared.LobbyActivityService = LobbyActivityService
+
+ThemeValue:GetPropertyChangedSignal("Value"):Connect(function()
+        task.defer(updateActiveFromTheme)
+end)
+
+task.defer(function()
+        updateActiveFromTheme()
+        for _, player in ipairs(Players:GetPlayers()) do
+                sendActivityStateTo(player)
+        end
+end)
+
+Players.PlayerAdded:Connect(function(player)
+        sendActivityStateTo(player)
+end)
+
+Players.PlayerRemoving:Connect(function(player)
+        playerCooldowns[player] = nil
+end)

--- a/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/ClientUI.client.lua
@@ -12,6 +12,8 @@ local AliveStatus = Remotes:WaitForChild("AliveStatus")
 local PlayerEliminatedRemote = Remotes:WaitForChild("PlayerEliminated")
 local RoundRewardsRemote = Remotes:WaitForChild("RoundRewards")
 local EventMonsterEffects = Remotes:WaitForChild("EventMonsterEffects")
+local LobbyActivityUpdate = Remotes:WaitForChild("LobbyActivityUpdate")
+local Workspace = workspace
 local State = game.ReplicatedStorage:WaitForChild("State")
 local RoundConfig = require(game.ReplicatedStorage.Modules.RoundConfig)
 local ThemeConfig = require(game.ReplicatedStorage.Modules.ThemeConfig)
@@ -195,6 +197,335 @@ eventWarningLabel.TextScaled = true
 eventWarningLabel.TextColor3 = Color3.fromRGB(255, 240, 240)
 eventWarningLabel.Text = ""
 eventWarningLabel.Parent = eventWarningFrame
+
+local activityFrame = Instance.new("Frame")
+activityFrame.Name = "LobbyActivity"
+activityFrame.Size = UDim2.new(0, 400, 0, 110)
+activityFrame.Position = UDim2.new(0.5, -200, 0, 12)
+activityFrame.BackgroundTransparency = 0.18
+activityFrame.BackgroundColor3 = Color3.fromRGB(20, 26, 36)
+activityFrame.BorderSizePixel = 0
+activityFrame.Visible = false
+activityFrame.Parent = gui
+
+local activityCorner = Instance.new("UICorner")
+activityCorner.CornerRadius = UDim.new(0, 14)
+activityCorner.Parent = activityFrame
+
+local activityStroke = Instance.new("UIStroke")
+activityStroke.ApplyStrokeMode = Enum.ApplyStrokeMode.Border
+activityStroke.Thickness = 2
+activityStroke.Color = Color3.fromRGB(140, 180, 255)
+activityStroke.Parent = activityFrame
+
+local activityTitle = Instance.new("TextLabel")
+activityTitle.Name = "Title"
+activityTitle.BackgroundTransparency = 1
+activityTitle.Size = UDim2.new(1, -24, 0, 30)
+activityTitle.Position = UDim2.new(0, 12, 0, 8)
+activityTitle.Font = Enum.Font.GothamBlack
+activityTitle.TextScaled = true
+activityTitle.TextWrapped = true
+activityTitle.TextXAlignment = Enum.TextXAlignment.Left
+activityTitle.TextColor3 = Color3.fromRGB(245, 248, 255)
+activityTitle.Text = "Lobby-activiteit"
+activityTitle.Parent = activityFrame
+
+local activityThemeLabel = Instance.new("TextLabel")
+activityThemeLabel.Name = "ThemeLabel"
+activityThemeLabel.BackgroundTransparency = 1
+activityThemeLabel.Size = UDim2.new(1, -24, 0, 22)
+activityThemeLabel.Position = UDim2.new(0, 12, 0, 42)
+activityThemeLabel.Font = Enum.Font.GothamSemibold
+activityThemeLabel.TextScaled = true
+activityThemeLabel.TextWrapped = true
+activityThemeLabel.TextXAlignment = Enum.TextXAlignment.Left
+activityThemeLabel.TextColor3 = Color3.fromRGB(200, 220, 255)
+activityThemeLabel.Text = "Thema: Onbekend"
+activityThemeLabel.Parent = activityFrame
+
+local activityDescriptionLabel = Instance.new("TextLabel")
+activityDescriptionLabel.Name = "Description"
+activityDescriptionLabel.BackgroundTransparency = 1
+activityDescriptionLabel.Size = UDim2.new(1, -24, 0, 32)
+activityDescriptionLabel.Position = UDim2.new(0, 12, 0, 64)
+activityDescriptionLabel.Font = Enum.Font.GothamMedium
+activityDescriptionLabel.TextScaled = true
+activityDescriptionLabel.TextWrapped = true
+activityDescriptionLabel.TextXAlignment = Enum.TextXAlignment.Left
+activityDescriptionLabel.TextColor3 = Color3.fromRGB(220, 228, 255)
+activityDescriptionLabel.Text = "Zoek de gemarkeerde zone en voltooi de uitdaging."
+activityDescriptionLabel.Parent = activityFrame
+
+local activityRewardLabel = Instance.new("TextLabel")
+activityRewardLabel.Name = "RewardLabel"
+activityRewardLabel.BackgroundTransparency = 1
+activityRewardLabel.Size = UDim2.new(1, -24, 0, 20)
+activityRewardLabel.Position = UDim2.new(0, 12, 0, 92)
+activityRewardLabel.Font = Enum.Font.GothamBold
+activityRewardLabel.TextScaled = true
+activityRewardLabel.TextWrapped = true
+activityRewardLabel.TextXAlignment = Enum.TextXAlignment.Left
+activityRewardLabel.TextColor3 = Color3.fromRGB(165, 235, 140)
+activityRewardLabel.Text = "Beloning: +0 coins  |  +0 XP"
+activityRewardLabel.Parent = activityFrame
+
+local waypointBillboard = Instance.new("BillboardGui")
+waypointBillboard.Name = "LobbyActivityWaypoint"
+waypointBillboard.Size = UDim2.new(0, 180, 0, 60)
+waypointBillboard.StudsOffsetWorldSpace = Vector3.new(0, 6, 0)
+waypointBillboard.Enabled = false
+waypointBillboard.AlwaysOnTop = true
+
+local waypointFrame = Instance.new("Frame")
+waypointFrame.Name = "Container"
+waypointFrame.Size = UDim2.new(1, 0, 1, 0)
+waypointFrame.BackgroundTransparency = 0.2
+waypointFrame.BackgroundColor3 = Color3.fromRGB(70, 120, 255)
+waypointFrame.BorderSizePixel = 0
+waypointFrame.Parent = waypointBillboard
+
+local waypointCorner = Instance.new("UICorner")
+waypointCorner.CornerRadius = UDim.new(0, 12)
+waypointCorner.Parent = waypointFrame
+
+local waypointTitle = Instance.new("TextLabel")
+waypointTitle.Name = "Title"
+waypointTitle.BackgroundTransparency = 1
+waypointTitle.Size = UDim2.new(1, -16, 0, 30)
+waypointTitle.Position = UDim2.new(0, 8, 0, 6)
+waypointTitle.Font = Enum.Font.GothamBold
+waypointTitle.TextScaled = true
+waypointTitle.TextWrapped = true
+waypointTitle.TextColor3 = Color3.fromRGB(255, 255, 255)
+waypointTitle.Text = "Activiteit"
+waypointTitle.Parent = waypointFrame
+
+local waypointAction = Instance.new("TextLabel")
+waypointAction.Name = "Action"
+waypointAction.BackgroundTransparency = 1
+waypointAction.Size = UDim2.new(1, -16, 0, 22)
+waypointAction.Position = UDim2.new(0, 8, 0, 34)
+waypointAction.Font = Enum.Font.GothamSemibold
+waypointAction.TextScaled = true
+waypointAction.TextWrapped = true
+waypointAction.TextColor3 = Color3.fromRGB(230, 240, 255)
+waypointAction.Text = "Voltooi uitdaging"
+waypointAction.Parent = waypointFrame
+
+local rewardToastFrame = Instance.new("Frame")
+rewardToastFrame.Name = "LobbyActivityReward"
+rewardToastFrame.Size = UDim2.new(0, 340, 0, 90)
+rewardToastFrame.Position = UDim2.new(0.5, -170, 0.65, 0)
+rewardToastFrame.BackgroundTransparency = 1
+rewardToastFrame.Visible = false
+rewardToastFrame.Parent = gui
+
+local rewardToastInner = Instance.new("Frame")
+rewardToastInner.Name = "Inner"
+rewardToastInner.Size = UDim2.new(1, 0, 1, 0)
+rewardToastInner.BackgroundTransparency = 1
+rewardToastInner.BackgroundColor3 = Color3.fromRGB(22, 70, 32)
+rewardToastInner.BorderSizePixel = 0
+rewardToastInner.Parent = rewardToastFrame
+
+local rewardToastCorner = Instance.new("UICorner")
+rewardToastCorner.CornerRadius = UDim.new(0, 14)
+rewardToastCorner.Parent = rewardToastInner
+
+local rewardToastStroke = Instance.new("UIStroke")
+rewardToastStroke.ApplyStrokeMode = Enum.ApplyStrokeMode.Border
+rewardToastStroke.Thickness = 2
+rewardToastStroke.Color = Color3.fromRGB(120, 220, 120)
+rewardToastStroke.Transparency = 1
+rewardToastStroke.Parent = rewardToastInner
+
+local rewardToastLabel = Instance.new("TextLabel")
+rewardToastLabel.Name = "Label"
+rewardToastLabel.BackgroundTransparency = 1
+rewardToastLabel.Size = UDim2.new(1, -20, 1, -20)
+rewardToastLabel.Position = UDim2.new(0, 10, 0, 10)
+rewardToastLabel.Font = Enum.Font.GothamBold
+rewardToastLabel.TextScaled = true
+rewardToastLabel.TextWrapped = true
+rewardToastLabel.TextColor3 = Color3.fromRGB(240, 255, 240)
+rewardToastLabel.TextTransparency = 1
+rewardToastLabel.Text = ""
+rewardToastLabel.Parent = rewardToastInner
+
+local lobbyActivityState = {
+zone = nil,
+theme = nil,
+themeName = nil,
+displayName = nil,
+}
+
+local rewardToastCounter = 0
+local rewardShowTween
+local rewardTextTween
+local rewardHideTween
+local rewardStrokeTween
+
+local function getActivityZoneFolder(zoneName)
+if not zoneName then
+return nil
+end
+local lobby = Workspace:FindFirstChild("Lobby")
+if not lobby then
+return nil
+end
+local zones = lobby:FindFirstChild("ActivityZones")
+if not zones then
+return nil
+end
+return zones:FindFirstChild(zoneName)
+end
+
+local function updateWaypoint(zoneName, displayName)
+local zoneFolder = getActivityZoneFolder(zoneName)
+local waypointPart
+local promptText
+if zoneFolder then
+waypointPart = zoneFolder:FindFirstChild("Waypoint")
+if waypointPart then
+local prompt = waypointPart:FindFirstChildWhichIsA("ProximityPrompt")
+if prompt then
+promptText = prompt.ActionText
+end
+end
+end
+if waypointPart and waypointPart:IsA("BasePart") then
+waypointBillboard.Enabled = true
+waypointBillboard.Adornee = waypointPart
+waypointBillboard.Parent = waypointPart
+waypointTitle.Text = displayName or zoneName or "Activiteit"
+waypointAction.Text = promptText or "Voltooi uitdaging"
+else
+waypointBillboard.Enabled = false
+waypointBillboard.Adornee = nil
+waypointBillboard.Parent = nil
+end
+end
+
+local function updateActivityPanel(payload)
+if type(payload) ~= "table" then
+return
+end
+lobbyActivityState.zone = payload.zone
+lobbyActivityState.theme = payload.theme
+lobbyActivityState.themeName = payload.themeDisplayName
+lobbyActivityState.displayName = payload.displayName or payload.zone or "Activiteit"
+local rewardCoins = 0
+local rewardXp = 0
+if type(payload.reward) == "table" then
+rewardCoins = math.floor(tonumber(payload.reward.coins or payload.reward.Coins) or 0)
+rewardXp = math.floor(tonumber(payload.reward.xp or payload.reward.XP) or 0)
+end
+local themeLabelText = payload.themeDisplayName or payload.theme or "Onbekend"
+local descriptionText = payload.description or "Zoek de gemarkeerde zone en voltooi de uitdaging."
+activityTitle.Text = string.format("Lobby-activiteit: %s", lobbyActivityState.displayName)
+activityThemeLabel.Text = string.format("Thema: %s", themeLabelText)
+activityDescriptionLabel.Text = descriptionText
+activityRewardLabel.Text = string.format("Beloning: +%d coins  |  +%d XP", rewardCoins, rewardXp)
+activityFrame.Visible = true
+local theme = ThemeConfig.Get(payload.theme)
+local accent = theme and theme.primaryColor or Color3.fromRGB(140, 180, 255)
+activityStroke.Color = accent
+waypointFrame.BackgroundColor3 = accent
+rewardToastStroke.Color = accent
+rewardToastInner.BackgroundColor3 = Color3.new(
+math.clamp(accent.R * 0.35, 0, 1),
+math.clamp(accent.G * 0.55, 0, 1),
+math.clamp(accent.B * 0.35, 0, 1)
+)
+updateWaypoint(payload.zone, lobbyActivityState.displayName)
+if not waypointBillboard.Enabled then
+task.delay(1, function()
+if lobbyActivityState.zone == payload.zone then
+updateWaypoint(payload.zone, lobbyActivityState.displayName)
+end
+end)
+end
+end
+
+local function showRewardToast(message)
+rewardToastCounter += 1
+local toastId = rewardToastCounter
+rewardToastLabel.Text = message
+rewardToastFrame.Visible = true
+rewardToastInner.BackgroundTransparency = 1
+rewardToastLabel.TextTransparency = 1
+rewardToastStroke.Transparency = 1
+if rewardShowTween then
+rewardShowTween:Cancel()
+end
+if rewardTextTween then
+rewardTextTween:Cancel()
+end
+if rewardHideTween then
+rewardHideTween:Cancel()
+end
+if rewardStrokeTween then
+rewardStrokeTween:Cancel()
+end
+local showInfo = TweenInfo.new(0.3, Enum.EasingStyle.Quad, Enum.EasingDirection.Out)
+rewardShowTween = TweenService:Create(rewardToastInner, showInfo, { BackgroundTransparency = 0.08 })
+rewardTextTween = TweenService:Create(rewardToastLabel, TweenInfo.new(0.28, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), { TextTransparency = 0 })
+rewardStrokeTween = TweenService:Create(rewardToastStroke, TweenInfo.new(0.28, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), { Transparency = 0 })
+rewardShowTween:Play()
+rewardTextTween:Play()
+rewardStrokeTween:Play()
+task.delay(4, function()
+if rewardToastCounter ~= toastId then
+return
+end
+local hideInfo = TweenInfo.new(0.35, Enum.EasingStyle.Quad, Enum.EasingDirection.In)
+rewardHideTween = TweenService:Create(rewardToastInner, hideInfo, { BackgroundTransparency = 1 })
+local hideTextTween = TweenService:Create(rewardToastLabel, hideInfo, { TextTransparency = 1 })
+local hideStroke = TweenService:Create(rewardToastStroke, hideInfo, { Transparency = 1 })
+rewardHideTween:Play()
+hideTextTween:Play()
+hideStroke:Play()
+hideTextTween.Completed:Connect(function()
+if rewardToastCounter == toastId then
+rewardToastFrame.Visible = false
+end
+end)
+end)
+end
+
+local function handleActivityReward(payload)
+if type(payload) ~= "table" then
+return
+end
+local displayName = payload.displayName or lobbyActivityState.displayName or payload.zone or "Activiteit"
+local applied = payload.applied or {}
+local coinsEarned = tonumber(applied.coins or applied.Coins) or 0
+local xpEarned = tonumber(applied.xp or applied.XP) or 0
+if coinsEarned == 0 and xpEarned == 0 and payload.reward then
+coinsEarned = tonumber(payload.reward.coins or payload.reward.Coins) or 0
+xpEarned = tonumber(payload.reward.xp or payload.reward.XP) or 0
+end
+local lines = {
+string.format("%s voltooid!", displayName),
+string.format("+%d Coins  |  +%d XP", coinsEarned, xpEarned),
+}
+local unlocks = applied.unlocks
+if type(unlocks) == "table" and #unlocks > 0 then
+local unlockLabels = {}
+for _, unlock in ipairs(unlocks) do
+if type(unlock) == "table" then
+unlockLabels[#unlockLabels + 1] = unlock.name or unlock.id or "Nieuwe ontgrendeling"
+elseif type(unlock) == "string" then
+unlockLabels[#unlockLabels + 1] = unlock
+end
+end
+if #unlockLabels > 0 then
+lines[#lines + 1] = "Ontgrendeld: " .. table.concat(unlockLabels, ", ")
+end
+end
+showRewardToast(table.concat(lines, "\n"))
+end
 
 local defaultEventWarningColor = eventWarningFrame.BackgroundColor3
 local eventWarningToken
@@ -506,6 +837,18 @@ EventMonsterEffects.OnClientEvent:Connect(function(stage, payload)
                 applyEventWarning(payload)
         elseif stage == "Stop" then
                 stopEventMonsterWarning()
+        end
+end)
+
+LobbyActivityUpdate.OnClientEvent:Connect(function(payload)
+        if type(payload) ~= "table" then
+                return
+        end
+        local action = payload.action
+        if action == "ActivityChanged" then
+                updateActivityPanel(payload)
+        elseif action == "RewardGranted" then
+                handleActivityReward(payload)
         end
 end)
 


### PR DESCRIPTION
## Summary
- introduce configurable lobby activity zones with default rewards and theme mappings in `RoundConfig`
- add `LobbyActivityService` to manage zone activation via CollectionService tags and award progression payouts when players complete active challenges
- extend the lobby UI with activity guidance, waypoint indicators, and reward toast handling powered by a new `LobbyActivityUpdate` remote event

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e97dbff2cc83229144585e2ee4dfa9